### PR TITLE
Add ability to import projects

### DIFF
--- a/internal/project/resource_project.go
+++ b/internal/project/resource_project.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapdefault"
@@ -227,6 +228,23 @@ func (r ProjectResource) Delete(ctx context.Context, req resource.DeleteRequest,
 	err = server.DeleteProject(projectName)
 	if err != nil {
 		resp.Diagnostics.AddError(fmt.Sprintf("Failed to remove project %q", projectName), err.Error())
+	}
+}
+
+func (r *ProjectResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	meta := common.ImportMetadata{
+		ResourceName:   "project",
+		RequiredFields: []string{"name"},
+	}
+
+	fields, diag := meta.ParseImportID(req.ID)
+	if diag != nil {
+		resp.Diagnostics.Append(diag)
+		return
+	}
+
+	for k, v := range fields {
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root(k), v)...)
 	}
 }
 

--- a/internal/project/resource_project_test.go
+++ b/internal/project/resource_project_test.go
@@ -95,6 +95,48 @@ func TestAccProject_updateConfig(t *testing.T) {
 	})
 }
 
+func TestAccProject_importBasic(t *testing.T) {
+	resourceName := "incus_project.project0"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProject_basic("project0"),
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportStateId:                        "project0",
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "name",
+			},
+		},
+	})
+}
+
+func TestAccProject_importConfig(t *testing.T) {
+	resourceName := "incus_project.project1"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProject_config("project1"),
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportStateId:                        "project1",
+				ImportState:                          true,
+				ImportStateVerify:                    false,
+				ImportStateVerifyIdentifierAttribute: "name",
+			},
+		},
+	})
+}
+
 func testAccProject_basic(name string) string {
 	return fmt.Sprintf(`
 resource "incus_project" "project0" {


### PR DESCRIPTION
This pull request adds the ability to import projects, such as with `tofu import incus_project.project1 project1`. I added tests as well using the tests used for networks as a reference.

My Go is rusty so let me know if I should improve this PR in any way!