### PR TITLE
resource/instance: Check PID not processes

### DIFF
--- a/internal/instance/resource_instance.go
+++ b/internal/instance/resource_instance.go
@@ -1080,7 +1080,7 @@ func waitForState(ctx context.Context, refreshFunc retry.StateRefreshFunc, targe
 // for virtual machines, which can report this metric only if the Incus agent has
 // started and has established a connection to the Incus server.
 func isInstanceOperational(s api.InstanceState) bool {
-	return isInstanceRunning(s) && s.Processes > 0
+	return isInstanceRunning(s) && s.Pid > 0
 }
 
 // isInstanceRunning returns true if its status is either "Running" or "Ready".


### PR DESCRIPTION
With virtual machines that don't run our agent, Processes will remain 0 forever. As the check is really meant to make sure that the instance has started, checking for the PID should be more reliable.