### PR TITLE
Add contributions guideline

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,72 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at coc@linuxcontainers.org. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at <https://www.contributor-covenant.org/version/1/4/code-of-conduct.html>
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see <https://www.contributor-covenant.org/faq>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,93 @@
+# Contributing
+
+The Incus team appreciates contributions to the project, through pull requests, issues on the [GitHub repository](https://github.com/lxc/terraform-provider-incus/issues), or discussions or questions on the [forum](https://discuss.linuxcontainers.org).
+
+Check the following guidelines before contributing to the project.
+
+## Code of Conduct
+
+When contributing, you must adhere to the Code of Conduct, which is available at: [`https://github.com/lxc/terraform-provider-incus/blob/main/CODE_OF_CONDUCT.md`](https://github.com/lxc/terraform-provider-incus/blob/main/CODE_OF_CONDUCT.md)
+
+## License and copyright
+
+By default, any contribution to this project is made under the Mozilla Public License 2.0.
+
+The author of a change remains the copyright holder of their code
+(no copyright assignment).
+
+## Pull requests
+
+Changes to this project should be proposed as pull requests on GitHub
+at: [`https://github.com/lxc/terraform-provider-incus`](https://github.com/lxc/terraform-provider-incus)
+
+Proposed changes will then go through review there and once approved,
+be merged in the main branch.
+
+### Commit structure
+
+Separate commits should be used for:
+
+- Documentation (`docs: Update XYZ` for files in `docs/`)
+- Resources (`<resource>: Add XYZ` for changes to resources in `internal/`)
+- Tests (`tests: Add test for XYZ` for changes to `tests/`)
+
+This structure makes it easiser for contributions to be reviewed.
+
+### Developer Certificate of Origin
+
+To improve tracking of contributions to this project we use the DCO 1.1
+and use a "sign-off" procedure for all changes going into the branch.
+
+The sign-off is a simple line at the end of the explanation for the
+commit which certifies that you wrote it or otherwise have the right
+to pass it on as an open-source contribution.
+
+```
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+660 York Street, Suite 102,
+San Francisco, CA 94110 USA
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
+
+An example of a valid sign-off line is:
+
+```
+Signed-off-by: Random J Developer <random@developer.org>
+```
+
+Use a known identity and a valid e-mail address.
+Sorry, no anonymous contributions are allowed.
+
+We also require each commit be individually signed-off by their author,
+even when part of a larger set. You may find `git commit -s` useful.


### PR DESCRIPTION
This pull request addresses https://github.com/lxc/terraform-provider-incus/issues/26 by adding CODE_OF_CONDUCT.md and CONTRIBUTING.md, establishing behavior standards and contribution guidelines for project participants similar to the [Incus Contributions Guideline](https://github.com/lxc/incus/blob/main/CONTRIBUTING.md).