### PR TITLE
Add Profile as data source

### DIFF
--- a/docs/data-sources/profile.md
+++ b/docs/data-sources/profile.md
@@ -1,0 +1,43 @@
+# incus_profile
+
+Provides information about an Incus profile.
+
+## Example Usage
+
+```hcl
+data "incus_profile" "default" {
+  name = "default"
+}
+
+resource "incus_instance" "d1" {
+  profiles = [data.incus_profile.default.name]
+  image    = "images:debian/12"
+  name     = "d1"
+}
+```
+
+## Argument Reference
+
+* `name` - **Required** - Name of the profile.
+
+* `project` - *Optional* - Name of the project where the profile will be stored.
+
+* `remote` - *Optional* - The remote in which the resource will be created. If
+  not provided, the provider's default remote will be used.
+
+## Attribute Reference
+
+* `device` - *Optional* - Device definition. See reference below.
+
+* `config` - *Optional* - Map of key/value pairs of
+  [instance config settings](https://linuxcontainers.org/incus/docs/main/reference/instance_options/).
+
+The `device` block supports:
+
+* `name` - **Required** - Name of the device.
+
+* `type` - **Required** - Type of the device Must be one of none, disk, nic,
+  unix-char, unix-block, usb, gpu, infiniband, proxy, unix-hotplug, tpm, pci.
+
+* `properties`- **Required** - Map of key/value pairs of
+  [device properties](https://linuxcontainers.org/incus/docs/main/reference/devices/).

--- a/internal/profile/datasource_profile.go
+++ b/internal/profile/datasource_profile.go
@@ -1,0 +1,127 @@
+package profile
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/lxc/terraform-provider-incus/internal/common"
+	"github.com/lxc/terraform-provider-incus/internal/errors"
+	provider_config "github.com/lxc/terraform-provider-incus/internal/provider-config"
+)
+
+func NewProfileDataSource() datasource.DataSource {
+	return &ProfileDataSource{}
+}
+
+// ProfileDataSource represent Incus profile data source.
+type ProfileDataSource struct {
+	provider *provider_config.IncusProviderConfig
+}
+
+func (d *ProfileDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = fmt.Sprintf("%s_profile", req.ProviderTypeName)
+}
+
+func (d *ProfileDataSource) Schema(_ context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"name": schema.StringAttribute{
+				Required: true,
+			},
+			"description": schema.StringAttribute{
+				Computed: true,
+			},
+
+			"project": schema.StringAttribute{
+				Optional: true,
+			},
+
+			"remote": schema.StringAttribute{
+				Optional: true,
+			},
+			"config": schema.MapAttribute{
+				Computed:    true,
+				ElementType: types.StringType,
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"device": schema.SetNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"name": schema.StringAttribute{
+							Computed: true,
+						},
+
+						"type": schema.StringAttribute{
+							Computed: true,
+						},
+
+						"properties": schema.MapAttribute{
+							Computed:    true,
+							ElementType: types.StringType,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *ProfileDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	data := req.ProviderData
+	if data == nil {
+		return
+	}
+
+	provider, ok := data.(*provider_config.IncusProviderConfig)
+	if !ok {
+		resp.Diagnostics.Append(errors.NewProviderDataTypeError(req.ProviderData))
+		return
+	}
+
+	d.provider = provider
+}
+
+func (d *ProfileDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var state ProfileModel
+
+	diags := req.Config.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	remote := state.Remote.ValueString()
+	project := state.Project.ValueString()
+	server, err := d.provider.InstanceServer(remote, project, "")
+	if err != nil {
+		resp.Diagnostics.Append(errors.NewInstanceServerError(err))
+		return
+	}
+
+	profileName := state.Name.ValueString()
+	profile, _, err := server.GetProfile(profileName)
+	if err != nil {
+		resp.Diagnostics.AddError(fmt.Sprintf("Failed to retrieve existing profile %q", profileName), err.Error())
+		return
+	}
+
+	config, diags := common.ToConfigMapType(ctx, profile.Config)
+	resp.Diagnostics.Append(diags...)
+
+	devices, diags := common.ToDeviceSetType(ctx, profile.Devices)
+	resp.Diagnostics.Append(diags...)
+
+	state.Name = types.StringValue(profile.Name)
+	state.Description = types.StringValue(profile.Description)
+	state.Devices = devices
+	state.Config = config
+
+	diags = resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -281,5 +281,7 @@ func (p *IncusProvider) Resources(_ context.Context) []func() resource.Resource 
 }
 
 func (p *IncusProvider) DataSources(_ context.Context) []func() datasource.DataSource {
-	return nil
+	return []func() datasource.DataSource{
+		profile.NewProfileDataSource,
+	}
 }


### PR DESCRIPTION
This pull request introduces a new data source for Incus profiles in the Terraform provider for Incus. 

This makes it possible to use an existing profile that was not created by Terraform, such as the default profile as mentioned in https://github.com/lxc/terraform-provider-incus/issues/58:

```hcl
data "incus_profile" "default" {
  name = "default"
}

resource "incus_instance" "d1" {
  profiles = [data.incus_profile.default.name]
  image    = "images:debian/12"
  name     = "d1"
}
```

Documentation:

* [`docs/data-sources/profile.md`](diffhunk://#diff-f89b844c330b464001c606af33eb2d17a51f35e6ac2ddfdd7ff962f1282d91f0R1-R43): Added documentation for the new `incus_profile` data source, including example usage, argument reference, and attribute reference.

Changes:

* [`internal/profile/datasource_profile.go`](diffhunk://#diff-38d4e811639c0dc37b55fe83b7c472ed914571a65d2bf5fe7256b64cb3501313R1-R127): Created a new Go file `datasource_profile.go` that includes the `ProfileDataSource` struct and its associated methods. This struct represents the Incus profile data source, and the methods handle the metadata, schema, configuration, and reading of the data source.
* [`internal/provider/provider.go`](diffhunk://#diff-58d6a027753b50994deb7e11e4a99dde423f35844986019bd9cea5e0c94aba22L284-R286): Updated the `DataSources` method of the `IncusProvider` struct to include the new `profile.NewProfileDataSource` function, which creates a new instance of the `ProfileDataSource`.