### PR TITLE
storage: Combine the inherited storage pool volume keys with the computed keys for storage pool volume

### DIFF
--- a/internal/storage/resource_storage_volume.go
+++ b/internal/storage/resource_storage_volume.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -349,7 +350,14 @@ func (r StorageVolumeResource) SyncState(ctx context.Context, tfState *tfsdk.Sta
 	}
 
 	// Extract user defined config and merge it with current config state.
-	stateConfig := common.StripConfig(vol.Config, m.Config, m.ComputedKeys())
+	inheritedPoolVolumeKeys, err := m.InheritedStoragePoolVolumeKeys(server, poolName)
+	if err != nil {
+		respDiags.AddError(fmt.Sprintf("Failed to retrieve storage pool config %q", volName), err.Error())
+		return respDiags
+	}
+
+	combinedComputedKeys := append(inheritedPoolVolumeKeys, m.ComputedKeys()...)
+	stateConfig := common.StripConfig(vol.Config, m.Config, combinedComputedKeys)
 
 	config, diags := common.ToConfigMapType(ctx, stateConfig, m.Config)
 	respDiags.Append(diags...)
@@ -380,4 +388,23 @@ func (_ StorageVolumeModel) ComputedKeys() []string {
 		"block.mount_options",
 		"volatile.",
 	}
+}
+
+func (_ StorageVolumeModel) InheritedStoragePoolVolumeKeys(server incus.InstanceServer, poolName string) ([]string, error) {
+	volumePrefix := "volume."
+	inheritedKeys := make([]string, 0)
+
+	pool, _, err := server.GetStoragePool(poolName)
+	if err != nil {
+		return nil, err
+	}
+
+	for key := range pool.Config {
+		if strings.HasPrefix(key, volumePrefix) {
+			inheritedKey := strings.TrimPrefix(key, volumePrefix)
+			inheritedKeys = append(inheritedKeys, inheritedKey)
+		}
+	}
+
+	return inheritedKeys, nil
 }


### PR DESCRIPTION
This pull request fixes https://github.com/lxc/terraform-provider-incus/issues/43:

In the event that a storage pool has a configuration value set for `volume.*`, the Terraform provider takes into account that this key is inherited (computed) to the storage volume after creation:

**Steps to reproduce:**

```hcl
resource "incus_storage_pool" "test" {
  name    = "test"
  project = "default"
  driver  = "zfs"
  config = {
    "volume.zfs.remove_snapshots" = "true"
  }
}

resource "incus_storage_volume" "test" {
  name         = "test"
  pool         = incus_storage_pool.test.name
  content_type = "block"
  config = {
    "size" = "1GiB"
  }
}
```

```bash
$ terraform apply
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the
following symbols:
  + create

Terraform will perform the following actions:

  # incus_storage_pool.test will be created
  + resource "incus_storage_pool" "test" {
      + config      = {
          + "volume.zfs.remove_snapshots" = "true"
        }
      + driver      = "zfs"
      + name        = "test"
      + project     = "default"
        # (1 unchanged attribute hidden)
    }

  # incus_storage_volume.test will be created
  + resource "incus_storage_volume" "test" {
      + config       = {
          + "size" = "1GiB"
        }
      + content_type = "block"
      + location     = (known after apply)
      + name         = "test"
      + pool         = "test"
      + target       = (known after apply)
      + type         = "custom"
        # (1 unchanged attribute hidden)
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

incus_storage_pool.test: Creating...
incus_storage_pool.test: Creation complete after 2s [name=test]
incus_storage_volume.test: Creating...
incus_storage_volume.test: Creation complete after 0s [name=test]

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
```

```bash
$ terraform plan
incus_storage_pool.test: Refreshing state... [name=test]
incus_storage_volume.test: Refreshing state... [name=test]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are
needed.
```