### PR TITLE
Support NULL values in configs

### DIFF
--- a/internal/common/incus_config.go
+++ b/internal/common/incus_config.go
@@ -14,14 +14,59 @@ func ToConfigMap(ctx context.Context, configMap types.Map) (map[string]string, d
 		return make(map[string]string), nil
 	}
 
-	config := make(map[string]string, len(configMap.Elements()))
-	diags := configMap.ElementsAs(ctx, &config, false)
-	return config, diags
+	// Convert to an intermediate nullable type.
+	tfConfig := make(map[string]*string, len(configMap.Elements()))
+	diags := configMap.ElementsAs(ctx, &tfConfig, false)
+	if diags != nil {
+		return nil, diags
+	}
+
+	// Then convert to our native type.
+	config := make(map[string]string, len(tfConfig))
+	for k, v := range tfConfig {
+		if v == nil {
+			continue
+		}
+
+		config[k] = *v
+	}
+
+	return config, nil
 }
 
 // ToConfigMapType converts map[string]string into config of type types.Map.
-func ToConfigMapType(ctx context.Context, config map[string]string) (types.Map, diag.Diagnostics) {
+func ToConfigMapType(ctx context.Context, config map[string]*string, modelConfig types.Map) (types.Map, diag.Diagnostics) {
+	// Add any missing nil values.
+	nullConfig := map[string]*string{}
+	if !modelConfig.IsNull() && !modelConfig.IsUnknown() {
+		_ = modelConfig.ElementsAs(context.Background(), &nullConfig, false)
+	}
+
+	for k, v := range nullConfig {
+		if v != nil {
+			continue
+		}
+
+		_, ok := config[k]
+		if !ok {
+			config[k] = nil
+		}
+	}
+
 	return types.MapValueFrom(ctx, types.StringType, config)
+}
+
+// ToNullableConfig converts map[string]string to map[string]*string.
+func ToNullableConfig(config map[string]string) map[string]*string {
+	nullConfig := make(map[string]*string, len(config))
+
+	for k := range config {
+		// Copy the value.
+		v := string(config[k])
+		nullConfig[k] = &v
+	}
+
+	return nullConfig
 }
 
 // MergeConfig merges resource (existing) configuration with user defined
@@ -56,14 +101,20 @@ func MergeConfig(resConfig map[string]string, usrConfig map[string]string, compu
 // file in order to be able to produce a consistent Terraform plan. If there
 // is a non-computed-key entry, it will be retained in the configuration and
 // will trigger an error.
-func StripConfig(resConfig map[string]string, usrConfig map[string]string, computedKeys []string) map[string]string {
-	config := make(map[string]string)
+func StripConfig(resConfig map[string]string, modelConfig types.Map, computedKeys []string) map[string]*string {
+	// Handle nulls in modelConfig.
+	usrConfig := map[string]*string{}
+	if !modelConfig.IsNull() && !modelConfig.IsUnknown() {
+		_ = modelConfig.ElementsAs(context.Background(), &usrConfig, false)
+	}
 
 	// Populate empty values from user config, so they do not "disappear"
 	// from the state.
+	config := make(map[string]*string)
+
 	for k, v := range usrConfig {
-		if v == "" {
-			config[k] = v
+		if v == nil {
+			config[k] = nil
 		}
 	}
 
@@ -77,7 +128,14 @@ func StripConfig(resConfig map[string]string, usrConfig map[string]string, compu
 
 		_, ok := usrConfig[k]
 		if ok || !isComputedKey(k, computedKeys) {
-			config[k] = v
+			if usrConfig[k] == nil && isComputedKey(k, computedKeys) {
+				// Keep as null.
+				config[k] = nil
+			} else {
+				// Copy the value.
+				v := string(resConfig[k])
+				config[k] = &v
+			}
 		}
 	}
 

--- a/internal/instance/resource_instance.go
+++ b/internal/instance/resource_instance.go
@@ -831,26 +831,23 @@ func (r InstanceResource) SyncState(ctx context.Context, tfState *tfsdk.State, s
 	}
 
 	// Extract user defined config and merge it with current resource config.
-	usrConfig, diags := common.ToConfigMap(ctx, m.Config)
-	respDiags.Append(diags...)
-
-	stateConfig := common.StripConfig(instance.Config, usrConfig, m.ComputedKeys())
+	stateConfig := common.StripConfig(instance.Config, m.Config, m.ComputedKeys())
 
 	// Extract enteries with "limits." prefix.
 	instanceLimits := make(map[string]string)
 	for k, v := range stateConfig {
 		key, ok := strings.CutPrefix(k, "limits.")
 		if ok {
-			instanceLimits[key] = v
+			instanceLimits[key] = *v
 			delete(stateConfig, k)
 		}
 	}
 
 	// Convert config, limits, profiles, and devices into schema type.
-	config, diags := common.ToConfigMapType(ctx, stateConfig)
+	config, diags := common.ToConfigMapType(ctx, stateConfig, m.Config)
 	respDiags.Append(diags...)
 
-	limits, diags := common.ToConfigMapType(ctx, instanceLimits)
+	limits, diags := common.ToConfigMapType(ctx, common.ToNullableConfig(instanceLimits), m.Config)
 	respDiags.Append(diags...)
 
 	profiles, diags := ToProfileListType(ctx, instance.Profiles)

--- a/internal/network/resource_network.go
+++ b/internal/network/resource_network.go
@@ -323,13 +323,10 @@ func (r NetworkResource) SyncState(ctx context.Context, tfState *tfsdk.State, se
 	}
 
 	// Extract user defined config and merge it with current config state.
-	usrConfig, diags := common.ToConfigMap(ctx, m.Config)
-	respDiags.Append(diags...)
-
-	stateConfig := common.StripConfig(network.Config, usrConfig, m.ComputedKeys())
+	stateConfig := common.StripConfig(network.Config, m.Config, m.ComputedKeys())
 
 	// Convert config state into schema type.
-	config, diags := common.ToConfigMapType(ctx, stateConfig)
+	config, diags := common.ToConfigMapType(ctx, stateConfig, m.Config)
 	respDiags.Append(diags...)
 
 	m.Name = types.StringValue(network.Name)

--- a/internal/network/resource_network_lb.go
+++ b/internal/network/resource_network_lb.go
@@ -368,7 +368,7 @@ func (r IncusNetworkLBResource) SyncState(ctx context.Context, tfState *tfsdk.St
 	ports, diags := ToLBPortSetType(ctx, lb.Ports)
 	respDiags.Append(diags...)
 
-	config, diags := common.ToConfigMapType(ctx, lb.Config)
+	config, diags := common.ToConfigMapType(ctx, common.ToNullableConfig(lb.Config), m.Config)
 	respDiags.Append(diags...)
 
 	m.Description = types.StringValue(lb.Description)

--- a/internal/network/resource_network_test.go
+++ b/internal/network/resource_network_test.go
@@ -48,6 +48,26 @@ func TestAccNetwork_description(t *testing.T) {
 	})
 }
 
+func TestAccNetwork_nullable(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetwork_nullable(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("incus_network.eth2", "name", "eth2"),
+					resource.TestCheckResourceAttr("incus_network.eth2", "type", "bridge"),
+					resource.TestCheckResourceAttr("incus_network.eth2", "description", "My network"),
+					resource.TestCheckResourceAttr("incus_network.eth2", "config.%", "2"),
+					resource.TestCheckNoResourceAttr("incus_network.eth2", "config.ipv4.address"),
+					resource.TestCheckResourceAttr("incus_network.eth2", "config.ipv6.address", "none"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccNetwork_attach(t *testing.T) {
 	profileName := petname.Generate(2, "-")
 	instanceName := petname.Generate(2, "-")
@@ -260,6 +280,23 @@ resource "incus_network" "eth1" {
   config = {
     "ipv4.address" = "10.150.19.1/24"
     "ipv6.address" = "fd42:474b:622d:259d::1/64"
+  }
+}
+`
+}
+
+func testAccNetwork_nullable() string {
+	return `
+locals {
+  foo = "bar"
+}
+
+resource "incus_network" "eth2" {
+  name        = "eth2"
+  description = "My network"
+  config = {
+    "ipv4.address" = local.foo == "bar" ? null : "10.0.0.1/24"
+    "ipv6.address" = "none"
   }
 }
 `

--- a/internal/network/resource_network_zone.go
+++ b/internal/network/resource_network_zone.go
@@ -275,7 +275,7 @@ func (r NetworkZoneResource) SyncState(ctx context.Context, tfState *tfsdk.State
 	}
 
 	// Convert config state into schema type.
-	config, diags := common.ToConfigMapType(ctx, zone.Config)
+	config, diags := common.ToConfigMapType(ctx, common.ToNullableConfig(zone.Config), m.Config)
 	if diags.HasError() {
 		return diags
 	}

--- a/internal/network/resource_network_zone_record.go
+++ b/internal/network/resource_network_zone_record.go
@@ -341,7 +341,7 @@ func (r NetworkZoneRecordResource) SyncState(ctx context.Context, tfState *tfsdk
 	entries, diags := ToZoneRecordEntrySetType(ctx, record.Entries)
 	respDiags.Append(diags...)
 
-	config, diags := common.ToConfigMapType(ctx, record.Config)
+	config, diags := common.ToConfigMapType(ctx, common.ToNullableConfig(record.Config), m.Config)
 	respDiags.Append(diags...)
 
 	m.Zone = types.StringValue(zoneName)

--- a/internal/profile/datasource_profile.go
+++ b/internal/profile/datasource_profile.go
@@ -108,7 +108,7 @@ func (d *ProfileDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		return
 	}
 
-	config, diags := common.ToConfigMapType(ctx, profile.Config)
+	config, diags := common.ToConfigMapType(ctx, common.ToNullableConfig(profile.Config), state.Config)
 	resp.Diagnostics.Append(diags...)
 
 	devices, diags := common.ToDeviceSetType(ctx, profile.Devices)

--- a/internal/profile/resource_profile.go
+++ b/internal/profile/resource_profile.go
@@ -326,7 +326,7 @@ func (r ProfileResource) SyncState(ctx context.Context, tfState *tfsdk.State, se
 	}
 
 	// Convert config state and devices into schema types.
-	config, diags := common.ToConfigMapType(ctx, profile.Config)
+	config, diags := common.ToConfigMapType(ctx, common.ToNullableConfig(profile.Config), m.Config)
 	respDiags.Append(diags...)
 
 	devices, diags := common.ToDeviceSetType(ctx, profile.Devices)

--- a/internal/project/resource_project.go
+++ b/internal/project/resource_project.go
@@ -277,13 +277,10 @@ func (r ProjectResource) SyncState(ctx context.Context, tfState *tfsdk.State, se
 	}
 
 	// Extract user defined config and merge it with current config state.
-	usrConfig, diags := common.ToConfigMap(ctx, m.Config)
-	respDiags.Append(diags...)
-
-	stateConfig := common.StripConfig(project.Config, usrConfig, m.ComputedKeys())
+	stateConfig := common.StripConfig(project.Config, m.Config, m.ComputedKeys())
 
 	// Convert config state into schema type.
-	config, diags := common.ToConfigMapType(ctx, stateConfig)
+	config, diags := common.ToConfigMapType(ctx, stateConfig, m.Config)
 	respDiags.Append(diags...)
 
 	m.Name = types.StringValue(project.Name)

--- a/internal/storage/resource_storage_bucket.go
+++ b/internal/storage/resource_storage_bucket.go
@@ -312,13 +312,10 @@ func (r StorageBucketResource) SyncState(ctx context.Context, tfState *tfsdk.Sta
 	}
 
 	// Extract user defined config and merge it with current config state.
-	userConfig, diags := common.ToConfigMap(ctx, m.Config)
-	respDiags.Append(diags...)
-
-	stateConfig := common.StripConfig(bucket.Config, userConfig, m.ComputedKeys())
+	stateConfig := common.StripConfig(bucket.Config, m.Config, m.ComputedKeys())
 
 	// Convert config state into schema type.
-	config, diags := common.ToConfigMapType(ctx, stateConfig)
+	config, diags := common.ToConfigMapType(ctx, stateConfig, m.Config)
 	respDiags.Append(diags...)
 
 	m.Name = types.StringValue(bucket.Name)

--- a/internal/storage/resource_storage_pool.go
+++ b/internal/storage/resource_storage_pool.go
@@ -312,13 +312,10 @@ func (r StoragePoolResource) SyncState(ctx context.Context, tfState *tfsdk.State
 	}
 
 	// Extract user defined config and merge it with current config state.
-	userConfig, diags := common.ToConfigMap(ctx, m.Config)
-	respDiags.Append(diags...)
-
-	stateConfig := common.StripConfig(pool.Config, userConfig, m.ComputedKeys(pool.Driver))
+	stateConfig := common.StripConfig(pool.Config, m.Config, m.ComputedKeys(pool.Driver))
 
 	// Convert config state into schema type.
-	config, diags := common.ToConfigMapType(ctx, stateConfig)
+	config, diags := common.ToConfigMapType(ctx, stateConfig, m.Config)
 	respDiags.Append(diags...)
 
 	m.Name = types.StringValue(pool.Name)

--- a/internal/storage/resource_storage_volume.go
+++ b/internal/storage/resource_storage_volume.go
@@ -349,12 +349,9 @@ func (r StorageVolumeResource) SyncState(ctx context.Context, tfState *tfsdk.Sta
 	}
 
 	// Extract user defined config and merge it with current config state.
-	userConfig, diags := common.ToConfigMap(ctx, m.Config)
-	respDiags.Append(diags...)
+	stateConfig := common.StripConfig(vol.Config, m.Config, m.ComputedKeys())
 
-	stateConfig := common.StripConfig(vol.Config, userConfig, m.ComputedKeys())
-
-	config, diags := common.ToConfigMapType(ctx, stateConfig)
+	config, diags := common.ToConfigMapType(ctx, stateConfig, m.Config)
 	respDiags.Append(diags...)
 
 	m.Name = types.StringValue(vol.Name)


### PR DESCRIPTION
Terraform allows for configuration to be set to NULL. This is generally assumed to be equivalent to not having put the configuration line in question and is particularly useful when dealing with conditional behaviors.

A couple of examples:

```
resource "incus_network" "this" {
  name = "foo"

  config = {
    "ipv4.address" = var.deploy == "production" ? "none" : null
  }
}

resource "incus_profile" "this" {
  name = "foo"

  config = {
    "environment.http_proxy" = var.deploy == "production" ? "http://my-proxy:3128" : null
    "environment.https_proxy" = var.deploy == "production" ? "http://my-proxy:3128" : null
  }
}
```

To handle this properly, a few changes are needed:
 - Read the Terraform config as a map[string]*string to allow for NULL
 - When set to NULL and config key doesn't exist, tell Terraform it's NULL
 - When set to NULL and config key is computed, tell Terraform it's NULL