### PR TITLE
Add network forward resource

### DIFF
--- a/docs/resources/network_forward.md
+++ b/docs/resources/network_forward.md
@@ -1,0 +1,108 @@
+# incus_network_forward
+
+Manages an Incus network forward.
+
+See Incus network forward [configuration reference](https://linuxcontainers.org/incus/docs/main/howto/network_forwards/) for how to configure network forwards.
+
+## Example Usage
+
+```hcl
+resource "incus_network" "my_network" {
+  name = "my-network"
+
+  config = {
+    "ipv4.address" = "10.150.19.1/24"
+    "ipv4.nat"     = "true"
+    "ipv6.address" = "fd42:474b:622d:259d::1/64"
+    "ipv6.nat"     = "true"
+  }
+}
+
+resource "incus_network_forward" "my_forward" {
+  network        = incus_network.my_network.name
+  listen_address = "10.150.19.10"
+
+  config = {
+    target_address = "10.150.19.111"
+  }
+
+  ports = [
+    {
+      description    = "SSH"
+      protocol       = "tcp"
+      listen_port    = "22"
+      target_port    = "2022"
+      target_address = "10.150.19.112"
+    },
+    {
+      description    = "HTTP"
+      protocol       = "tcp"
+      listen_port    = "80"
+      target_port    = "8080"
+      target_address = "10.150.19.112"
+    }
+  ]
+}
+```
+
+## Argument Reference
+
+* `network` - **Required** - Name of the network.
+
+* `listen_address` - **Required** - IP address to listen on.
+
+* `description` - *Optional* - Description of the network forward.
+
+* `config` - *Optional* - Map of key/value pairs of
+  [network forward config settings](hhttps://linuxcontainers.org/incus/docs/main/howto/network_forwards/).
+
+* `project` - *Optional* - Name of the project where the network forward will be created.
+
+* `remote` - *Optional* - The remote in which the resource will be created. If
+  not provided, the provider's default remote will be used.
+
+* `ports` - *Optional* - List of port specifications. See reference below.
+
+The network forward port supports:
+
+* `protocol` - **Required** - Protocol for the port(s) (`tcp` or `udp`). If not set then `tcp` will be used.
+
+* `listen_port` - **Required** - Listen port(s) (e.g. `80,90-100`)
+
+* `target_address` - **Required** - IP address to forward to
+
+* `target_port` - *Optional* - T arget port(s) (e.g. `70,80-90` or `90`), same as listen_port if empty
+
+* `description` - *Optional* - Description of port(s)
+
+## Importing
+
+Import ID syntax: `[<remote>:][<project>/]<network-name>/<listen-address>`
+
+* `<remote>` - *Optional* - Remote name.
+* `<project>` - *Optional* - Project name.
+* `<network-name>` - **Required** - Network name.
+* `<listen-address>` - **Required** - IP Listen Address.
+
+### Import example
+
+Example using terraform import command:
+
+```shell
+$ terraform import incus_network_forward.forward1 proj/my-network/10.150.19.10
+```
+
+Example using the import block (only available in Terraform v1.5.0 and later):
+
+```hcl
+resource "incus_network_forward" "forward1" {
+  network_name   = "my-network"
+  listen_address = "10.150.19.10"
+  project        = "proj"
+}
+
+import {
+  to = incus_network_forward.forward1
+  id = "proj/my-network/10.150.19.10"
+}
+```

--- a/internal/network/resource_network_forward.go
+++ b/internal/network/resource_network_forward.go
@@ -1,0 +1,428 @@
+package network
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/lxc/incus/v6/client"
+	"github.com/lxc/incus/v6/shared/api"
+
+	"github.com/lxc/terraform-provider-incus/internal/common"
+	"github.com/lxc/terraform-provider-incus/internal/errors"
+	provider_config "github.com/lxc/terraform-provider-incus/internal/provider-config"
+)
+
+// NetworkForwardModel resource data model that matches the schema.
+type NetworkForwardModel struct {
+	Network       types.String `tfsdk:"network"`
+	ListenAddress types.String `tfsdk:"listen_address"`
+	Ports         types.Set    `tfsdk:"ports"`
+	Description   types.String `tfsdk:"description"`
+	Project       types.String `tfsdk:"project"`
+	Remote        types.String `tfsdk:"remote"`
+	Config        types.Map    `tfsdk:"config"`
+}
+
+// NetworkForwardModel resource data model that matches the schema.
+type NetworkForwardPortModel struct {
+	Description   types.String `tfsdk:"description"`
+	Protocol      types.String `tfsdk:"protocol"`
+	ListenPort    types.String `tfsdk:"listen_port"`
+	TargetPort    types.String `tfsdk:"target_port"`
+	TargetAddress types.String `tfsdk:"target_address"`
+}
+
+// NetworkForwardResource represent network forward resource.
+type NetworkForwardResource struct {
+	provider *provider_config.IncusProviderConfig
+}
+
+func NewNetworkForwardResource() resource.Resource {
+	return &NetworkForwardResource{}
+}
+
+func (r *NetworkForwardResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = fmt.Sprintf("%s_network_forward", req.ProviderTypeName)
+}
+
+func (r *NetworkForwardResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	portObjectType := getPortObjectType()
+
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"network": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+
+			"listen_address": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+
+			"description": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				Default:  stringdefault.StaticString(""),
+			},
+
+			"project": schema.StringAttribute{
+				Optional: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
+				},
+			},
+
+			"remote": schema.StringAttribute{
+				Optional: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+
+			"config": schema.MapAttribute{
+				Optional:    true,
+				Computed:    true,
+				ElementType: types.StringType,
+			},
+
+			"ports": schema.SetNestedAttribute{
+				Optional: true,
+				Computed: true,
+				Default:  setdefault.StaticValue(types.SetNull(portObjectType)),
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"description": schema.StringAttribute{
+							Optional:    true,
+							Description: "Port description",
+						},
+
+						"protocol": schema.StringAttribute{
+							Optional:    true,
+							Computed:    true,
+							Default:     stringdefault.StaticString("tcp"),
+							Description: "Port protocol",
+							Validators: []validator.String{
+								stringvalidator.OneOf("tcp", "udp"),
+							},
+						},
+
+						"listen_port": schema.StringAttribute{
+							Required:    true,
+							Description: "Listen port to forward",
+						},
+
+						"target_port": schema.StringAttribute{
+							Required:    true,
+							Description: "Target port to forward listen port to",
+						},
+
+						"target_address": schema.StringAttribute{
+							Required:    true,
+							Description: "Target address to forward listen port to",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func getPortObjectType() types.ObjectType {
+	return types.ObjectType{
+		AttrTypes: map[string]attr.Type{
+			"description":    types.StringType,
+			"protocol":       types.StringType,
+			"listen_port":    types.StringType,
+			"target_port":    types.StringType,
+			"target_address": types.StringType,
+		},
+	}
+}
+
+func (r *NetworkForwardResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	data := req.ProviderData
+	if data == nil {
+		return
+	}
+
+	provider, ok := data.(*provider_config.IncusProviderConfig)
+	if !ok {
+		resp.Diagnostics.Append(errors.NewProviderDataTypeError(req.ProviderData))
+		return
+	}
+
+	r.provider = provider
+}
+
+func (r *NetworkForwardResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan NetworkForwardModel
+
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	remote := plan.Remote.ValueString()
+	project := plan.Project.ValueString()
+	server, err := r.provider.InstanceServer(remote, project, "")
+	if err != nil {
+		resp.Diagnostics.Append(errors.NewInstanceServerError(err))
+		return
+	}
+
+	ports, diags := ToNetworkForwardPortList(ctx, plan.Ports)
+	resp.Diagnostics.Append(diags...)
+
+	config, diags := common.ToConfigMap(ctx, plan.Config)
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	networkName := plan.Network.ValueString()
+	listenAddress := plan.ListenAddress.ValueString()
+
+	createRequest := api.NetworkForwardsPost{
+		ListenAddress: listenAddress,
+		NetworkForwardPut: api.NetworkForwardPut{
+			Description: plan.Description.ValueString(),
+			Ports:       ports,
+			Config:      config,
+		},
+	}
+
+	err = server.CreateNetworkForward(networkName, createRequest)
+	if err != nil {
+		resp.Diagnostics.AddError(fmt.Sprintf("Failed to create network forward for %q", listenAddress), err.Error())
+		return
+	}
+
+	diags = r.SyncState(ctx, &resp.State, server, plan)
+	resp.Diagnostics.Append(diags...)
+}
+
+func ToNetworkForwardPortList(ctx context.Context, portsSet types.Set) ([]api.NetworkForwardPort, diag.Diagnostics) {
+	if portsSet.IsNull() || portsSet.IsUnknown() {
+		return []api.NetworkForwardPort{}, nil
+	}
+
+	modelPorts := make([]NetworkForwardPortModel, 0, len(portsSet.Elements()))
+	diags := portsSet.ElementsAs(ctx, &modelPorts, false)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	ports := make([]api.NetworkForwardPort, 0, len(modelPorts))
+	for _, modelPort := range modelPorts {
+		port := api.NetworkForwardPort{
+			Description:   modelPort.Description.ValueString(),
+			Protocol:      modelPort.Protocol.ValueString(),
+			ListenPort:    modelPort.ListenPort.ValueString(),
+			TargetPort:    modelPort.TargetPort.ValueString(),
+			TargetAddress: modelPort.TargetAddress.ValueString(),
+		}
+
+		ports = append(ports, port)
+	}
+
+	return ports, nil
+}
+
+func (r *NetworkForwardResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state NetworkForwardModel
+
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	remote := state.Remote.ValueString()
+	project := state.Project.ValueString()
+	server, err := r.provider.InstanceServer(remote, project, "")
+	if err != nil {
+		resp.Diagnostics.Append(errors.NewInstanceServerError(err))
+		return
+	}
+
+	diags = r.SyncState(ctx, &resp.State, server, state)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r *NetworkForwardResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan NetworkForwardModel
+
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	remote := plan.Remote.ValueString()
+	project := plan.Project.ValueString()
+	server, err := r.provider.InstanceServer(remote, project, "")
+	if err != nil {
+		resp.Diagnostics.Append(errors.NewInstanceServerError(err))
+		return
+	}
+
+	ports, diags := ToNetworkForwardPortList(ctx, plan.Ports)
+	resp.Diagnostics.Append(diags...)
+
+	config, diags := common.ToConfigMap(ctx, plan.Config)
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	networkName := plan.Network.ValueString()
+	listenAddress := plan.ListenAddress.ValueString()
+
+	updateRequest := api.NetworkForwardPut{
+		Description: plan.Description.ValueString(),
+		Ports:       ports,
+		Config:      config,
+	}
+
+	_, etag, err := server.GetNetworkForward(networkName, listenAddress)
+	if err != nil {
+		resp.Diagnostics.AddError(fmt.Sprintf("Failed to retrieve network forward for %q", listenAddress), err.Error())
+	}
+
+	err = server.UpdateNetworkForward(networkName, listenAddress, updateRequest, etag)
+	if err != nil {
+		resp.Diagnostics.AddError(fmt.Sprintf("Failed to update network forward for %q", listenAddress), err.Error())
+		return
+	}
+
+	diags = r.SyncState(ctx, &resp.State, server, plan)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r *NetworkForwardResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state NetworkForwardModel
+
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	remote := state.Remote.ValueString()
+	project := state.Project.ValueString()
+	server, err := r.provider.InstanceServer(remote, project, "")
+	if err != nil {
+		resp.Diagnostics.Append(errors.NewInstanceServerError(err))
+		return
+	}
+
+	networkName := state.Network.ValueString()
+	listenAddress := state.ListenAddress.ValueString()
+
+	err = server.DeleteNetworkForward(networkName, listenAddress)
+	if err != nil {
+		resp.Diagnostics.AddError(fmt.Sprintf("Failed to delete network forward for %q", listenAddress), err.Error())
+	}
+}
+
+func (r *NetworkForwardResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	meta := common.ImportMetadata{
+		ResourceName:   "network_forward",
+		RequiredFields: []string{"network", "listen_address"},
+	}
+
+	fields, diags := meta.ParseImportID(req.ID)
+	if diags != nil {
+		resp.Diagnostics.Append(diags)
+		return
+	}
+
+	for k, v := range fields {
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root(k), v)...)
+	}
+}
+
+func (r *NetworkForwardResource) SyncState(ctx context.Context, tfState *tfsdk.State, server incus.InstanceServer, m NetworkForwardModel) diag.Diagnostics {
+	networkName := m.Network.ValueString()
+	listenAddress := m.ListenAddress.ValueString()
+	networkForward, _, err := server.GetNetworkForward(networkName, listenAddress)
+	if err != nil {
+		if errors.IsNotFoundError(err) {
+			tfState.RemoveResource(ctx)
+			return nil
+		}
+
+		return diag.Diagnostics{diag.NewErrorDiagnostic(
+			fmt.Sprintf("Failed to retrieve network forward %q", listenAddress), err.Error(),
+		)}
+	}
+
+	ports, diags := ToNetworkForwardPortSetType(ctx, networkForward.Ports)
+	if diags.HasError() {
+		return diags
+	}
+
+	config, diags := common.ToConfigMapType(ctx, common.ToNullableConfig(networkForward.Config), m.Config)
+	if diags.HasError() {
+		return diags
+	}
+
+	m.Description = types.StringValue(networkForward.Description)
+	m.Ports = ports
+	m.Config = config
+
+	return tfState.Set(ctx, &m)
+}
+
+func ToNetworkForwardPortSetType(ctx context.Context, ports []api.NetworkForwardPort) (types.Set, diag.Diagnostics) {
+	portObjectType := getPortObjectType()
+	nilSet := types.SetNull(portObjectType)
+
+	if len(ports) == 0 {
+		return nilSet, nil
+	}
+
+	var portList []attr.Value
+	for _, port := range ports {
+		portMap := map[string]attr.Value{
+			"description":    types.StringValue(port.Description),
+			"protocol":       types.StringValue(port.Protocol),
+			"listen_port":    types.StringValue(port.ListenPort),
+			"target_port":    types.StringValue(port.TargetPort),
+			"target_address": types.StringValue(port.TargetAddress),
+		}
+
+		portObject, diags := types.ObjectValue(portObjectType.AttrTypes, portMap)
+		if diags.HasError() {
+			return nilSet, diags
+		}
+
+		portList = append(portList, portObject)
+	}
+
+	return types.SetValue(portObjectType, portList)
+}

--- a/internal/network/resource_network_forward_test.go
+++ b/internal/network/resource_network_forward_test.go
@@ -1,0 +1,145 @@
+package network_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/dustinkirkland/golang-petname"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	"github.com/lxc/terraform-provider-incus/internal/acctest"
+)
+
+func TestAccNetworkForward_basic(t *testing.T) {
+	networkName := getNetworkName()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkForward(networkName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("incus_network_forward.forward", "listen_address", "10.150.19.10"),
+					resource.TestCheckResourceAttr("incus_network_forward.forward", "description", "Network Forward"),
+					resource.TestCheckResourceAttr("incus_network_forward.forward", "config.target_address", "10.150.19.111"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetworkForward_Ports(t *testing.T) {
+	networkName := getNetworkName()
+
+	entry1 := map[string]string{
+		"description":    "SSH",
+		"protocol":       "tcp",
+		"listen_port":    "22",
+		"target_port":    "2022",
+		"target_address": "10.150.19.112",
+	}
+
+	entry2 := map[string]string{
+		"description":    "HTTP",
+		"protocol":       "tcp",
+		"listen_port":    "80",
+		"target_port":    "8080",
+		"target_address": "10.150.19.112",
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkForward_withPorts(networkName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("incus_network_forward.forward", "listen_address", "10.150.19.10"),
+					resource.TestCheckResourceAttr("incus_network_forward.forward", "description", "Network Forward"),
+					resource.TestCheckResourceAttr("incus_network_forward.forward", "config.target_address", "10.150.19.111"),
+					resource.TestCheckTypeSetElemNestedAttrs("incus_network_forward.forward", "ports.*", entry1),
+					resource.TestCheckTypeSetElemNestedAttrs("incus_network_forward.forward", "ports.*", entry2),
+				),
+			},
+		},
+	})
+}
+
+func testAccNetworkForward(networkName string) string {
+	return fmt.Sprintf(`
+resource "incus_network" "forward" {
+  name = "%s"
+
+  config = {
+    "ipv4.address" = "10.150.19.1/24"
+    "ipv4.nat"     = "true"
+    "ipv6.address" = "fd42:474b:622d:259d::1/64"
+    "ipv6.nat"     = "true"
+  }
+}
+
+resource "incus_network_forward" "forward" {
+  network        = incus_network.forward.name
+  description    = "Network Forward"
+  listen_address = "10.150.19.10"
+
+  config = {
+	target_address = "10.150.19.111"
+  }
+}
+`, networkName)
+}
+
+func testAccNetworkForward_withPorts(networkName string) string {
+	return fmt.Sprintf(`
+resource "incus_network" "forward" {
+  name = "%s"
+
+  config = {
+    "ipv4.address" = "10.150.19.1/24"
+    "ipv4.nat"     = "true"
+    "ipv6.address" = "fd42:474b:622d:259d::1/64"
+    "ipv6.nat"     = "true"
+  }
+}
+
+resource "incus_network_forward" "forward" {
+  network        = incus_network.forward.name
+  description    = "Network Forward"
+  listen_address = "10.150.19.10"
+
+  config = {
+	target_address = "10.150.19.111"
+  }
+
+  ports = [
+    {
+      description    = "SSH"
+      protocol       = "tcp"
+      listen_port    = "22"
+      target_port    = "2022"
+      target_address = "10.150.19.112"
+    },
+    {
+      description    = "HTTP"
+      protocol       = "tcp"
+      listen_port    = "80"
+      target_port    = "8080"
+      target_address = "10.150.19.112"
+    }
+  ]
+}
+`, networkName)
+}
+
+func getNetworkName() string {
+	maxLength := 15
+	networkName := petname.Generate(2, "-")
+
+	if len(networkName) > maxLength {
+		return networkName[:maxLength]
+	}
+
+	return networkName
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -272,6 +272,7 @@ func (p *IncusProvider) Resources(_ context.Context) []func() resource.Resource 
 		network.NewNetworkZoneResource,
 		network.NewNetworkZoneRecordResource,
 		network.NewNetworkAclResource,
+		network.NewNetworkForwardResource,
 		profile.NewProfileResource,
 		project.NewProjectResource,
 		storage.NewStoragePoolResource,


### PR DESCRIPTION
This pull requests adds the network forward resource (see https://github.com/lxc/terraform-provider-incus/issues/35).

**Examples**

```hcl
resource "incus_network" "my_network" {
  name = "my-network"

  config = {
    "ipv4.address" = "10.150.19.1/24"
    "ipv4.nat"     = "true"
    "ipv6.address" = "fd42:474b:622d:259d::1/64"
    "ipv6.nat"     = "true"
  }
}

resource "incus_network_forward" "my_forward" {
  network        = incus_network.my_network.name
  listen_address = "10.150.19.10"

  config = {
    target_address = "10.150.19.111"
  }

  ports = [
    {
      description    = "SSH"
      protocol       = "tcp"
      listen_port    = "22"
      target_port    = "2022"
      target_address = "10.150.19.112"
    },
    {
      description    = "HTTP"
      protocol       = "tcp"
      listen_port    = "80"
      target_port    = "8080"
      target_address = "10.150.19.112"
    }
  ]
}
```

**What's been done**

- Added `network_forward.go` which implements the network forward resource
- Added `network_forward_test.go` which implements various tests for the network forward resource
- Added documentation of the network forward resource