### PR TITLE
Fix: If Image Remote is not set, the instance server is used as the image server.

### DIFF
--- a/internal/instance/resource_instance.go
+++ b/internal/instance/resource_instance.go
@@ -421,10 +421,16 @@ func (r InstanceResource) Create(ctx context.Context, req resource.CreateRequest
 			image = imageParts[1]
 		}
 
-		imageServer, err := r.provider.ImageServer(imageRemote)
-		if err != nil {
-			resp.Diagnostics.Append(errors.NewImageServerError(err))
-			return
+		var imageServer incus.ImageServer
+		if imageRemote == "" {
+			// Use the instance server as an image server if image remote is empty.
+			imageServer = server
+		} else {
+			imageServer, err = r.provider.ImageServer(imageRemote)
+			if err != nil {
+				resp.Diagnostics.Append(errors.NewImageServerError(err))
+				return
+			}
 		}
 
 		var imageInfo *api.Image


### PR DESCRIPTION
If Image Remote is not set, the instance server is used as the image server.

This pull request fixes: https://github.com/lxc/terraform-provider-incus/issues/94

**Example:**

```tf
resource "incus_project" "test" {
  name = "test"

  config = {
    "features.images"   = true
    "features.profiles" = false
  }
}

resource "incus_image" "alpine" {
  source_remote = "images"
  source_image  = "alpine/3.18/arm64"
  project       = incus_project.test.name
}

resource "incus_instance" "test1" {
  name    = "test1"
  image   = "images:alpine/3.18/arm64"
  project = incus_project.test.name
}

resource "incus_instance" "test2" {
  name    = "test2"
  image   = incus_image.alpine.fingerprint
  project = incus_project.test.name
}
```

