### PR TITLE
Architecture becomes argument

### DIFF
--- a/docs/resources/image.md
+++ b/docs/resources/image.md
@@ -38,11 +38,11 @@ resource "incus_instance" "test1" {
 * `remote` - *Optional* - The remote in which the resource will be created. If
 	not provided, the provider's default remote will be used.
 
+* `architecture` - The image architecture (e.g. x86_64, aarch64). See [Architectures](https://linuxcontainers.org/incus/docs/main/architectures/) for all possible values.
+
 ## Attribute Reference
 
 The following attributes are exported:
-
-* `architecture` - The image architecture (e.g. amd64, i386).
 
 * `created_at` - The datetime of image creation, in Unix time.
 

--- a/internal/image/resource_image_test.go
+++ b/internal/image/resource_image_test.go
@@ -241,6 +241,30 @@ func TestAccImage_instanceFromImageFingerprint(t *testing.T) {
 	})
 }
 
+func TestAccImage_architecture(t *testing.T) {
+	projectName := petname.Name()
+	architecture := "aarch64"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccImage_architecture(projectName, architecture),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("incus_project.project1", "name", projectName),
+					resource.TestCheckResourceAttr("incus_image.img1", "source_remote", "images"),
+					resource.TestCheckResourceAttr("incus_image.img1", "source_image", "alpine/edge"),
+					resource.TestCheckResourceAttr("incus_image.img1", "project", projectName),
+					resource.TestCheckNoResourceAttr("incus_image.img1", "aliases"),
+					resource.TestCheckResourceAttr("incus_image.img1", "copied_aliases.#", "0"),
+					resource.TestCheckResourceAttr("incus_image.img1", "architecture", architecture),
+				),
+			},
+		},
+	})
+}
+
 func testAccImage_basic() string {
 	return `
 resource "incus_image" "img1" {
@@ -365,4 +389,18 @@ resource "incus_instance" "inst" {
   }
 }
 	`, project, instanceName)
+}
+
+func testAccImage_architecture(project string, architecture string) string {
+	return fmt.Sprintf(`
+resource "incus_project" "project1" {
+  name = "%s"
+}
+resource "incus_image" "img1" {
+  source_remote = "images"
+  source_image  = "alpine/edge"
+  project       = incus_project.project1.name
+  architecture  = "%s"
+}
+	`, project, architecture)
 }

--- a/internal/image/schema_validators.go
+++ b/internal/image/schema_validators.go
@@ -1,0 +1,39 @@
+package image
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+	"github.com/lxc/incus/v6/shared/osarch"
+)
+
+type architectureValidator struct{}
+
+func (v architectureValidator) Description(ctx context.Context) string {
+	supportedArchitecturesList := strings.Join(osarch.SupportedArchitectures(), ", ")
+	return fmt.Sprintf("Attribute architecture value must be one of: %s.", supportedArchitecturesList)
+}
+
+func (v architectureValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v architectureValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	value := req.ConfigValue.ValueString()
+	if value == "" {
+		return
+	}
+
+	for _, supportedArchitecture := range osarch.SupportedArchitectures() {
+		if value == supportedArchitecture {
+			return
+		}
+	}
+
+	resp.Diagnostics.AddAttributeError(req.Path, "Invalid architecture",
+		v.Description(ctx),
+	)
+}


### PR DESCRIPTION
This pull request fixes https://github.com/lxc/terraform-provider-incus/issues/92 by making `Architecture` an argument.

**Example**

```hcl
resource "incus_project" "test" {
  name = "test"
}


resource "incus_image" "ubuntu" {
  project = incus_project.test.name

  source_remote = "images"
  source_image  = "ubuntu/noble"
  architecture  = "aarch64"
}
```

**What's been done**
- Changed `incus_image` to make Architecture an argument and use `IncusClient#GetImageAliasArchitectures` to determine the correct image alias
- Added test to validate the argument
- Updated documentation