### PR TITLE
instance: Add OCI container support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,8 @@ jobs:
 
           INCUS_TOKEN=$(incus config trust add terraform --quiet)
           incus remote add localhost "${INCUS_TOKEN}"
+  
+          incus remote add docker https://docker.io --protocol=oci
 
       - name: Configure OVN
         run: |

--- a/internal/instance/resource_instance.go
+++ b/internal/instance/resource_instance.go
@@ -437,8 +437,8 @@ func (r InstanceResource) Create(ctx context.Context, req resource.CreateRequest
 
 		// Gather info about source image.
 		conn, _ := imageServer.GetConnectionInfo()
-		if conn.Protocol == "simplestreams" {
-			// Optimisation for simplestreams.
+		if conn.Protocol != "incus" {
+			// Optimisation for public servers.
 			imageInfo = &api.Image{}
 			imageInfo.Public = true
 			imageInfo.Fingerprint = image
@@ -912,6 +912,7 @@ func (r InstanceResource) SyncState(ctx context.Context, tfState *tfsdk.State, s
 // ComputedKeys returns list of computed config keys.
 func (_ InstanceModel) ComputedKeys() []string {
 	return []string{
+		"environment.",
 		"image.",
 		"volatile.",
 	}

--- a/internal/provider-config/config.go
+++ b/internal/provider-config/config.go
@@ -118,7 +118,7 @@ func (p *IncusProviderConfig) ImageServer(remoteName string) (incus.ImageServer,
 		return nil, err
 	}
 
-	if connInfo.Protocol == "simplestreams" || connInfo.Protocol == "incus" {
+	if connInfo.Protocol == "simplestreams" || connInfo.Protocol == "incus" || connInfo.Protocol == "oci" {
 		return server.(incus.ImageServer), nil
 	}
 
@@ -169,6 +169,11 @@ func (p *IncusProviderConfig) server(remoteName string) (incus.Server, error) {
 
 	switch incusRemoteConfig.Protocol {
 	case "simplestreams":
+		server, err = p.getIncusConfigImageServer(remoteName)
+		if err != nil {
+			return nil, err
+		}
+	case "oci":
 		server, err = p.getIncusConfigImageServer(remoteName)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This pull requests adds an initial support to create a OCI container with this provider.

**Example**

```hcl
resource "incus_instance" "redis" {
  project = "default"
  name    = "redis"
  image   = "docker:redis"
}
```

**What's been done** 

- Added support for OCI protocol
- Added `environment.` to the computed keys list in `resource_instance.go`
- Added test to run an OCI image
- Added DockerHub as remote for test environment