### PR TITLE
Use another instance as the source for a new instance

### DIFF
--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -72,12 +72,34 @@ resource "incus_instance" "instance2" {
 }
 ```
 
+## Example to create a new instance from an existing instance
+
+```hcl
+resource "incus_instance" "instance1" {
+  project = "default"
+  name    = "instance1"
+  image   = "images:debian/12"
+}
+
+resource "incus_instance" "instance2" {
+  project = "default"
+  name    = "instance2"
+
+  source_instance = {
+    project = "default"
+    name    = "instance1"
+  }
+}
+```
+
 ## Argument Reference
 
 * `name` - **Required** - Name of the instance.
 
-* `image` - **Required** - Base image from which the instance will be created. Must
+* `image` - *Optional* - Base image from which the instance will be created. Must
   specify [an image accessible from the provider remote](https://linuxcontainers.org/incus/docs/main/reference/remote_image_servers/).
+
+* `source_instance` - *Optional* - The source instance from which the instance will be created. See reference below.
 
 * `description` - *Optional* - Description of the instance.
 
@@ -110,6 +132,14 @@ resource "incus_instance" "instance2" {
 	not provided, the provider's default remote will be used.
 
 * `target` - *Optional* - Specify a target node in a cluster.
+
+The `source_instance` block supports:
+
+* `project` - **Required** - Name of the project in which the source instance exists.
+
+* `name` - **Required** - Name of the source instance.
+
+* `snapshot`- *Optiona** - Name of the snapshot of the source instance
 
 The `device` block supports:
 


### PR DESCRIPTION
This pull requests adds the `source_instance` argument to use another instance as the source for a new instance, see https://github.com/lxc/terraform-provider-incus/issues/80

**Examples**

_From current instance:_

```hcl
resource "incus_instance" "instance1" {
  project = "default"
  name    = "instance1"
  image   = "images:debian/12"
}

resource "incus_instance" "instance2" {
  project = "default"
  name    = "instance1"

  source_instance = {
    project = "default"
    name    = incus_instance.instance1.name
  }
}
```

_From a snapshot of the source instance:_

```hcl
resource "incus_instance" "instance1" {
  project = "default"
  name    = "instance1"
  image   = "images:debian/12"
}

resource "incus_instance_snapshot" "snapshot1" {
  project  = "default"
  name     = "snap0"
  instance = incus_instance.instance1.name
}

resource "incus_instance" "instance2" {
  project = "default"
  name    = "instance1"

  source_instance = {
    project = "default"
    name    = incus_instance.instance1.name
    snapshot = incus_instance_snapshot.snapshot1.name
  }
}
```

**What's been done**:
- Added `source_instance` as attribute and validate that only `image` or `source_instance` can be set.
- Added test for `source_instance` with and without snapshot
- Adjusted the test for the use case when no image is set
- Updated docs for `incus_instance`