### PR TITLE
Fix Image Server Link

### DIFF
--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -97,7 +97,7 @@ resource "incus_instance" "instance2" {
 * `name` - **Required** - Name of the instance.
 
 * `image` - *Optional* - Base image from which the instance will be created. Must
-  specify [an image accessible from the provider remote](https://linuxcontainers.org/incus/docs/main/reference/remote_image_servers/).
+  specify [an image accessible from the provider remote](https://linuxcontainers.org/incus/docs/main/reference/image_servers/).
 
 * `source_instance` - *Optional* - The source instance from which the instance will be created. See reference below.
 


### PR DESCRIPTION
The old link returns a 404. Looking at the git history, it looks like the file was renamed in https://github.com/lxc/incus/commit/9d18f53a9ad3990082af65b1b74a722082989525.