### PR TITLE
docs: align instance limit config docs with observed behavior

### DIFF
--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -13,7 +13,10 @@ resource "incus_instance" "instance1" {
 
   config = {
     "boot.autostart" = true
-    "limits.cpu" = 2
+  }
+
+  limits = {
+    "cpu" = 2
   }
 }
 ```
@@ -119,6 +122,9 @@ resource "incus_instance" "instance2" {
 
 * `config` - *Optional* - Map of key/value pairs of
 	[instance config settings](https://linuxcontainers.org/incus/docs/main/reference/instance_options/).
+
+* `limits` - *Optional* - Map of key/value pairs of 
+        [resource limit config settings](https://linuxcontainers.org/incus/docs/main/reference/instance_options/#resource-limits), without the `limits.` prefix in the keys.
 
 * `project` - *Optional* - Name of the project where the instance will be spawned.
 


### PR DESCRIPTION
Got this error message when trying to use the *Basic Example* as-is:

```
Config keys with "limits." prefix must be provided in "limits" map instead.
```

Adding a dedicated `limits` map fixed the problem for me, so I'm proposing to adjust the example accordingly.

Since `limits`  wasn't mentioned in the *Argument Reference* yet, I'm proposing to add it there, too. This is just a draft, maybe someone can find a better wording. (I'm very new to Incus.)

Manually tested with:
```
OpenTofu v1.8.2
on linux_amd64
+ provider registry.opentofu.org/lxc/incus v0.1.4
```