### PR TITLE
Support public image servers

### DIFF
--- a/internal/instance/resource_instance.go
+++ b/internal/instance/resource_instance.go
@@ -831,7 +831,7 @@ func (r InstanceResource) createInstanceFromImage(ctx context.Context, server in
 	}
 
 	image := plan.Image.ValueString()
-	imageRemote := plan.Remote.ValueString()
+	imageRemote := ""
 	imageParts := strings.SplitN(image, ":", 2)
 	if len(imageParts) == 2 {
 		imageRemote = imageParts[0]

--- a/internal/provider-config/config.go
+++ b/internal/provider-config/config.go
@@ -179,15 +179,22 @@ func (p *IncusProviderConfig) server(remoteName string) (incus.Server, error) {
 			return nil, err
 		}
 	default:
-		server, err = p.getIncusConfigInstanceServer(remoteName)
-		if err != nil {
-			return nil, err
-		}
+		if incusRemoteConfig.Public {
+			server, err = p.getIncusConfigImageServer(remoteName)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			server, err = p.getIncusConfigInstanceServer(remoteName)
+			if err != nil {
+				return nil, err
+			}
 
-		// Ensure that Incusversion meets the provider's version constraint.
-		err := verifyIncusServerVersion(server.(incus.InstanceServer))
-		if err != nil {
-			return nil, fmt.Errorf("Remote %q: %v", remoteName, err)
+			// Ensure that Incus version meets the provider's version constraint.
+			err := verifyIncusServerVersion(server.(incus.InstanceServer))
+			if err != nil {
+				return nil, fmt.Errorf("Remote %q: %v", remoteName, err)
+			}
 		}
 	}
 


### PR DESCRIPTION
This pull requests fixes https://github.com/lxc/terraform-provider-incus/issues/119 as we support public image servers now.

**Example**

```hcl
resource "incus_instance" "a1" {
  remote = "instance-server"
  name   = "a1"
  image  = "public-image-server:my-custom-alpine"
}
```