### PR TITLE
Cluster group resource

### DIFF
--- a/docs/resources/cluster_group.md
+++ b/docs/resources/cluster_group.md
@@ -1,0 +1,62 @@
+# incus_cluster_group
+
+Manages an Incus cluster group.
+
+## Example Usage
+
+```hcl
+resource "incus_cluster_group" "amd64" {
+  name        = "amd64"
+  description = "x86-64 nodes"
+}
+```
+
+## Argument Reference
+
+* `name` - **Required** - Name of the cluster group.
+
+* `config` - *Optional* - Map of key/value pairs of
+  [cluster group config settings](https://linuxcontainers.org/incus/docs/main/howto/cluster_groups/#configuration-options).
+
+* `remote` - *Optional* - The remote in which the resource will be created. If
+  not provided, the provider's default remote will be used.
+
+## Attribute Reference
+
+No attributes are exported.
+
+## Importing
+
+Cluster groups can be imported with the following command:
+
+```shell
+terraform import incus_cluster_group.my_group [<remote>:]<name>
+```
+
+## Importing
+
+Import ID syntax: `[<remote>:]<name>`
+
+* `<remote>` - *Optional* - Remote name.
+* `<name>` - **Required** - Cluster group name.
+
+### Import example
+
+Example using terraform import command:
+
+```shell
+terraform import incus_cluster_group.my_group my_group
+```
+
+Example using the import block (only available in Terraform v1.5.0 and later):
+
+```hcl
+resource "incus_cluster_group" "my_group" {
+  name = "my_group"
+}
+
+import {
+  to = incus_cluster_group.my_group
+  id = "my_group"
+}
+```

--- a/docs/resources/cluster_group_assignment.md
+++ b/docs/resources/cluster_group_assignment.md
@@ -1,0 +1,68 @@
+# incus_cluster_group_assignment
+
+Manages an Incus cluster group assignment.
+
+## Example Usage
+
+```hcl
+resource "incus_cluster_group" "amd64" {
+  name        = "amd64"
+  description = "x86-64 nodes"
+}
+
+resource "incus_cluster_group_assignment" "node_11" {
+  cluster_group = incus_cluster_group.amd64.name
+  member        = "node_1"
+}
+```
+
+## Argument Reference
+
+* `cluster_group` - **Required** - Name of the cluster group.
+
+* `member` - **Required** - Name of the cluster group member.
+
+* `remote` - *Optional* - The remote in which the resource will be created. If
+  not provided, the provider's default remote will be used.
+
+## Attribute Reference
+
+No attributes are exported.
+
+## Importing
+
+Cluster groups can be imported with the following command:
+
+```shell
+terraform import incus_cluster_group_assignment.member [<remote>:]/<cluster_group>/<member>
+```
+
+## Importing
+
+Import ID syntax: `[<remote>:]/<cluster_group>/<member>`
+
+* `<remote>` - *Optional* - Remote name.
+* `<cluster_group>` - **Required** - Cluster group name.
+* `<member>` - **Required** - Cluster group member name.
+
+### Import example
+
+Example using terraform import command:
+
+```shell
+terraform import incus_cluster_group_assignment.node_1 /my-cluster/node-1
+```
+
+Example using the import block (only available in Terraform v1.5.0 and later):
+
+```hcl
+resource "incus_cluster_group_assignment" "node_1" {
+  cluster_group = "my-cluster"
+  member        = "node-1"
+}
+
+import {
+  to = incus_cluster_group.mygroup
+  id = "/my-cluster/node-1"
+}
+```

--- a/internal/clustering/resource_cluster_group.go
+++ b/internal/clustering/resource_cluster_group.go
@@ -1,0 +1,267 @@
+package clustering
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/lxc/incus/v6/client"
+	"github.com/lxc/incus/v6/shared/api"
+
+	"github.com/lxc/terraform-provider-incus/internal/common"
+	"github.com/lxc/terraform-provider-incus/internal/errors"
+	provider_config "github.com/lxc/terraform-provider-incus/internal/provider-config"
+)
+
+type ClusterGroupModel struct {
+	Name        types.String `tfsdk:"name"`
+	Description types.String `tfsdk:"description"`
+	Remote      types.String `tfsdk:"remote"`
+	Config      types.Map    `tfsdk:"config"`
+}
+
+type ClusterGroupResource struct {
+	provider *provider_config.IncusProviderConfig
+}
+
+func NewClusterGroupResource() resource.Resource {
+	return &ClusterGroupResource{}
+}
+
+func (r *ClusterGroupResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = fmt.Sprintf("%s_cluster_group", req.ProviderTypeName)
+}
+
+func (r *ClusterGroupResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"name": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+
+			"description": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				Default:  stringdefault.StaticString(""),
+			},
+
+			"remote": schema.StringAttribute{
+				Optional: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+
+			"config": schema.MapAttribute{
+				Optional:    true,
+				Computed:    true,
+				ElementType: types.StringType,
+				Default:     mapdefault.StaticValue(types.MapValueMust(types.StringType, map[string]attr.Value{})),
+			},
+		},
+	}
+}
+
+func (r *ClusterGroupResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	data := req.ProviderData
+	if data == nil {
+		return
+	}
+
+	provider, ok := data.(*provider_config.IncusProviderConfig)
+	if !ok {
+		resp.Diagnostics.Append(errors.NewProviderDataTypeError(req.ProviderData))
+		return
+	}
+
+	r.provider = provider
+}
+
+func (r *ClusterGroupResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan ClusterGroupModel
+
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	remote := plan.Remote.ValueString()
+	server, err := r.provider.InstanceServer(remote, "", "")
+	if err != nil {
+		resp.Diagnostics.Append(errors.NewInstanceServerError(err))
+		return
+	}
+
+	config, diags := common.ToConfigMap(ctx, plan.Config)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	clusterGroup := api.ClusterGroupsPost{
+		Name: plan.Name.ValueString(),
+		ClusterGroupPut: api.ClusterGroupPut{
+			Description: plan.Description.ValueString(),
+			Config:      config,
+		},
+	}
+
+	err = server.CreateClusterGroup(clusterGroup)
+	if err != nil {
+		resp.Diagnostics.AddError(fmt.Sprintf("Failed to create cluster group %q", clusterGroup.Name), err.Error())
+		return
+	}
+
+	diags = r.SyncState(ctx, &resp.State, server, plan)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r *ClusterGroupResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state ClusterGroupModel
+
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	remote := state.Remote.ValueString()
+	server, err := r.provider.InstanceServer(remote, "", "")
+	if err != nil {
+		resp.Diagnostics.Append(errors.NewInstanceServerError(err))
+		return
+	}
+
+	diags = r.SyncState(ctx, &resp.State, server, state)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r *ClusterGroupResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan ClusterGroupModel
+
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	remote := plan.Remote.ValueString()
+	server, err := r.provider.InstanceServer(remote, "", "")
+	if err != nil {
+		resp.Diagnostics.Append(errors.NewInstanceServerError(err))
+		return
+	}
+
+	clusterGroupName := plan.Name.ValueString()
+	clusterGroup, etag, err := server.GetClusterGroup(clusterGroupName)
+	if err != nil {
+		resp.Diagnostics.AddError(fmt.Sprintf("Failed to retrieve cluster group %q", clusterGroupName), err.Error())
+		return
+	}
+
+	config, diags := common.ToConfigMap(ctx, plan.Config)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	updatedClusterGroup := api.ClusterGroupPut{
+		Description: plan.Description.ValueString(),
+		Config:      config,
+		Members:     clusterGroup.Members,
+	}
+
+	err = server.UpdateClusterGroup(clusterGroupName, updatedClusterGroup, etag)
+	if err != nil {
+		resp.Diagnostics.AddError(fmt.Sprintf("Failed to update cluster group %q", clusterGroupName), err.Error())
+		return
+	}
+
+	diags = r.SyncState(ctx, &resp.State, server, plan)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r *ClusterGroupResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state ClusterGroupModel
+
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	remote := state.Remote.ValueString()
+	server, err := r.provider.InstanceServer(remote, "", "")
+	if err != nil {
+		resp.Diagnostics.Append(errors.NewInstanceServerError(err))
+		return
+	}
+
+	clusterGroupName := state.Name.ValueString()
+	err = server.DeleteClusterGroup(clusterGroupName)
+	if err != nil {
+		resp.Diagnostics.AddError(fmt.Sprintf("Failed to remove cluster group %q", clusterGroupName), err.Error())
+	}
+}
+
+func (r *ClusterGroupResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	meta := common.ImportMetadata{
+		ResourceName:   "cluster_group",
+		RequiredFields: []string{"name"},
+	}
+
+	fields, diag := meta.ParseImportID(req.ID)
+	if diag != nil {
+		resp.Diagnostics.Append(diag)
+		return
+	}
+
+	for k, v := range fields {
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root(k), v)...)
+	}
+}
+
+// SyncState fetches the server's current state for a cluster group and updates
+// the provided model. It then applies this updated model as the new state
+// in Terraform.
+func (r *ClusterGroupResource) SyncState(ctx context.Context, tfState *tfsdk.State, server incus.InstanceServer, m ClusterGroupModel) diag.Diagnostics {
+	var respDiags diag.Diagnostics
+
+	clusterGroupName := m.Name.ValueString()
+	clusterGroup, _, err := server.GetClusterGroup(clusterGroupName)
+	if err != nil {
+		if errors.IsNotFoundError(err) {
+			tfState.RemoveResource(ctx)
+			return nil
+		}
+
+		respDiags.AddError(fmt.Sprintf("Failed to retrieve cluster group %q", clusterGroupName), err.Error())
+		return respDiags
+	}
+
+	config, diags := common.ToConfigMapType(ctx, common.ToNullableConfig(clusterGroup.Config), m.Config)
+	respDiags.Append(diags...)
+	if respDiags.HasError() {
+		return respDiags
+	}
+
+	m.Name = types.StringValue(clusterGroup.Name)
+	m.Description = types.StringValue(clusterGroup.Description)
+	m.Config = config
+
+	return tfState.Set(ctx, &m)
+}

--- a/internal/clustering/resource_cluster_group_assignment.go
+++ b/internal/clustering/resource_cluster_group_assignment.go
@@ -1,0 +1,258 @@
+package clustering
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/lxc/incus/v6/client"
+	"github.com/lxc/incus/v6/shared/api"
+	"github.com/lxc/terraform-provider-incus/internal/common"
+	"github.com/lxc/terraform-provider-incus/internal/errors"
+	provider_config "github.com/lxc/terraform-provider-incus/internal/provider-config"
+)
+
+type ClusterGroupAssignmentModel struct {
+	Remote       types.String `tfsdk:"remote"`
+	ClusterGroup types.String `tfsdk:"cluster_group"`
+	Member       types.String `tfsdk:"member"`
+}
+
+type ClusterGroupAssignmentResource struct {
+	provider *provider_config.IncusProviderConfig
+}
+
+func NewClusterGroupAssignmentResource() resource.Resource {
+	return &ClusterGroupAssignmentResource{}
+}
+
+func (r *ClusterGroupAssignmentResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = fmt.Sprintf("%s_cluster_group_assignment", req.ProviderTypeName)
+}
+
+func (r *ClusterGroupAssignmentResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"remote": schema.StringAttribute{
+				Optional: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+
+			"cluster_group": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+
+			"member": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+		},
+	}
+}
+
+func (r *ClusterGroupAssignmentResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	data := req.ProviderData
+	if data == nil {
+		return
+	}
+
+	provider, ok := data.(*provider_config.IncusProviderConfig)
+	if !ok {
+		resp.Diagnostics.Append(errors.NewProviderDataTypeError(req.ProviderData))
+		return
+	}
+
+	r.provider = provider
+}
+
+func (r *ClusterGroupAssignmentResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan ClusterGroupAssignmentModel
+
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	clusterMemberName := plan.Member.ValueString()
+	remote := plan.Remote.ValueString()
+	server, err := r.provider.InstanceServer(remote, "", "")
+	if err != nil {
+		resp.Diagnostics.Append(errors.NewInstanceServerError(err))
+		return
+	}
+
+	clusterMemberNames, err := server.GetClusterMemberNames()
+	if err != nil {
+		resp.Diagnostics.AddError(fmt.Sprintf("Failed to retrieve cluster member names"), err.Error())
+		return
+	}
+
+	if !containsClusterMember(clusterMemberNames, clusterMemberName) {
+		resp.Diagnostics.AddError(fmt.Sprintf("Member with name %q is not part of the cluster", clusterMemberName), "")
+		return
+	}
+
+	clusterGroupName := plan.ClusterGroup.ValueString()
+	clusterGroup, etag, err := server.GetClusterGroup(clusterGroupName)
+	if err != nil {
+		resp.Diagnostics.AddError(fmt.Sprintf("Failed to retrieve cluster group %q", clusterGroupName), err.Error())
+		return
+	}
+
+	if containsClusterMember(clusterGroup.Members, clusterMemberName) {
+		resp.Diagnostics.AddError(fmt.Sprintf("Member with name %q is already assigned", clusterMemberName), "")
+		return
+	}
+
+	updatedClusterMembers := append(clusterGroup.Members, clusterMemberName)
+	updatedClusterGroup := api.ClusterGroupPut{
+		Description: clusterGroup.Description,
+		Members:     updatedClusterMembers,
+	}
+
+	err = server.UpdateClusterGroup(clusterGroupName, updatedClusterGroup, etag)
+	if err != nil {
+		resp.Diagnostics.AddError(fmt.Sprintf("Failed to assign member %q to cluster group %q", clusterMemberName, clusterGroupName), err.Error())
+		return
+	}
+
+	diags = r.SyncState(ctx, &resp.State, server, plan)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r *ClusterGroupAssignmentResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state ClusterGroupAssignmentModel
+
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	remote := state.Remote.ValueString()
+	server, err := r.provider.InstanceServer(remote, "", "")
+	if err != nil {
+		resp.Diagnostics.Append(errors.NewInstanceServerError(err))
+		return
+	}
+
+	diags = r.SyncState(ctx, &resp.State, server, state)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r *ClusterGroupAssignmentResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	// A replacement is always forced for this resource if a value is changed in the model.
+}
+
+func (r *ClusterGroupAssignmentResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state ClusterGroupAssignmentModel
+
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	remote := state.Remote.ValueString()
+	server, err := r.provider.InstanceServer(remote, "", "")
+	if err != nil {
+		resp.Diagnostics.Append(errors.NewInstanceServerError(err))
+		return
+	}
+
+	clusterGroupName := state.ClusterGroup.ValueString()
+	clusterGroup, etag, err := server.GetClusterGroup(clusterGroupName)
+	if err != nil {
+		resp.Diagnostics.AddError(fmt.Sprintf("Failed to retrieve cluster group %q", clusterGroupName), err.Error())
+		return
+	}
+
+	clusterMemberName := state.Member.ValueString()
+	updatedClusterMembers := removeClusterMember(clusterGroup.Members, clusterMemberName)
+	updatedClusterGroup := api.ClusterGroupPut{
+		Description: clusterGroup.Description,
+		Members:     updatedClusterMembers,
+	}
+
+	err = server.UpdateClusterGroup(clusterGroupName, updatedClusterGroup, etag)
+	if err != nil {
+		resp.Diagnostics.AddError(fmt.Sprintf("Failed to remove member %q from cluster group %q", clusterMemberName, clusterGroupName), err.Error())
+		return
+	}
+
+	diags = r.SyncState(ctx, &resp.State, server, state)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r *ClusterGroupAssignmentResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	meta := common.ImportMetadata{
+		ResourceName:   "cluster_group_assignment",
+		RequiredFields: []string{"cluster_group", "member"},
+	}
+
+	fields, diag := meta.ParseImportID(req.ID)
+	if diag != nil {
+		resp.Diagnostics.Append(diag)
+		return
+	}
+
+	for k, v := range fields {
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root(k), v)...)
+	}
+}
+
+// SyncState fetches the server's current state for a cluster group and updates
+// the provided model. It then applies this updated model as the new state
+// in Terraform.
+func (r *ClusterGroupAssignmentResource) SyncState(ctx context.Context, tfState *tfsdk.State, server incus.InstanceServer, m ClusterGroupAssignmentModel) diag.Diagnostics {
+	var respDiags diag.Diagnostics
+
+	clusterGroupName := m.ClusterGroup.ValueString()
+	clusterGroup, _, err := server.GetClusterGroup(clusterGroupName)
+	if err != nil {
+		if errors.IsNotFoundError(err) {
+			tfState.RemoveResource(ctx)
+			return nil
+		}
+
+		respDiags.AddError(fmt.Sprintf("Failed to retrieve cluster group %q", clusterGroupName), err.Error())
+		return respDiags
+	}
+
+	m.ClusterGroup = types.StringValue(clusterGroup.Name)
+
+	return tfState.Set(ctx, &m)
+}
+
+func containsClusterMember(clusterMembers []string, clusterMemberName string) bool {
+	for _, member := range clusterMembers {
+		if member == clusterMemberName {
+			return true
+		}
+	}
+	return false
+}
+
+func removeClusterMember(clusterMembers []string, clusterMemberName string) []string {
+	var result []string
+	for _, item := range clusterMembers {
+		if item != clusterMemberName {
+			result = append(result, item)
+		}
+	}
+	return result
+}

--- a/internal/clustering/resource_cluster_group_assignment_test.go
+++ b/internal/clustering/resource_cluster_group_assignment_test.go
@@ -1,0 +1,48 @@
+package clustering_test
+
+import (
+	"fmt"
+	"testing"
+
+	petname "github.com/dustinkirkland/golang-petname"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	"github.com/lxc/terraform-provider-incus/internal/acctest"
+)
+
+func TestAccClusterGroupAssignment_basic(t *testing.T) {
+	clusterGroupName := petname.Generate(2, "-")
+	clusterGroupMemberName := "node-1"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckClustering(t)
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterGroupAssignment_basic(clusterGroupName, clusterGroupMemberName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("incus_cluster_group_assignment.group1_node1", "cluster_group", clusterGroupName),
+					resource.TestCheckResourceAttr("incus_cluster_group_assignment.group1_node1", "member", clusterGroupMemberName),
+				),
+			},
+		},
+	})
+}
+
+func testAccClusterGroupAssignment_basic(clusterGroupName string, clusterGroupMemberName string) string {
+	return fmt.Sprintf(`
+resource "incus_cluster_group" "group1" {
+  name   = "%[1]s"
+}
+
+resource "incus_cluster_group_assignment" "group1_node1" {
+  cluster_group = incus_cluster_group.group1.name
+  member        = "%[2]s"
+}
+
+node-1
+`, clusterGroupName, clusterGroupMemberName)
+}

--- a/internal/clustering/resource_cluster_group_test.go
+++ b/internal/clustering/resource_cluster_group_test.go
@@ -1,0 +1,71 @@
+package clustering_test
+
+import (
+	"fmt"
+	"testing"
+
+	petname "github.com/dustinkirkland/golang-petname"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	"github.com/lxc/terraform-provider-incus/internal/acctest"
+)
+
+func TestAccClusterGroup_basic(t *testing.T) {
+	clusterGroupName := petname.Generate(2, "-")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckClustering(t)
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterGroup_basic(clusterGroupName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("incus_cluster_group.group1", "name", clusterGroupName),
+					resource.TestCheckResourceAttr("incus_cluster_group.group1", "description", ""),
+				),
+			},
+		},
+	})
+}
+
+func TestAccClusterGroup_description(t *testing.T) {
+	clusterGroupName := petname.Generate(2, "-")
+	description := petname.Adjective()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckClustering(t)
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterGroup_description(clusterGroupName, description),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("incus_cluster_group.group1", "name", clusterGroupName),
+					resource.TestCheckResourceAttr("incus_cluster_group.group1", "description", description),
+				),
+			},
+		},
+	})
+}
+
+func testAccClusterGroup_basic(name string) string {
+	return fmt.Sprintf(`
+resource "incus_cluster_group" "group1" {
+  name   = "%s"
+}
+`, name)
+}
+
+func testAccClusterGroup_description(name string, description string) string {
+	return fmt.Sprintf(`
+resource "incus_cluster_group" "group1" {
+  name        = "%s"
+  description = "%s"
+}
+`, name, description)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -16,6 +16,7 @@ import (
 	incus_config "github.com/lxc/incus/v6/shared/cliconfig"
 	incus_shared "github.com/lxc/incus/v6/shared/util"
 
+	"github.com/lxc/terraform-provider-incus/internal/clustering"
 	"github.com/lxc/terraform-provider-incus/internal/image"
 	"github.com/lxc/terraform-provider-incus/internal/instance"
 	"github.com/lxc/terraform-provider-incus/internal/network"
@@ -262,21 +263,23 @@ func (p *IncusProvider) Configure(ctx context.Context, req provider.ConfigureReq
 
 func (p *IncusProvider) Resources(_ context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
+		clustering.NewClusterGroupAssignmentResource,
+		clustering.NewClusterGroupResource,
 		image.NewImageResource,
 		instance.NewInstanceResource,
 		instance.NewInstanceSnapshotResource,
-		network.NewNetworkResource,
-		network.NewNetworkLBResource,
-		network.NewNetworkZoneResource,
-		network.NewNetworkZoneRecordResource,
 		network.NewNetworkAclResource,
 		network.NewNetworkForwardResource,
+		network.NewNetworkLBResource,
+		network.NewNetworkResource,
+		network.NewNetworkZoneRecordResource,
+		network.NewNetworkZoneResource,
 		profile.NewProfileResource,
 		project.NewProjectResource,
+		storage.NewStorageBucketKeyResource,
+		storage.NewStorageBucketResource,
 		storage.NewStoragePoolResource,
 		storage.NewStorageVolumeResource,
-		storage.NewStorageBucketResource,
-		storage.NewStorageBucketKeyResource,
 	}
 }
 


### PR DESCRIPTION
**Description**
This pull requests adds the cluster group and cluster group assignment resource and fixes https://github.com/lxc/terraform-provider-incus/issues/121.

I decided to make an assignment an explicit resource as I have seen done by other [providers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_account_assignment).

_Example_:

 ```hcl
resource "incus_cluster_group" "amd64" {
  name        = "amd64"
  description = "x86 machines"
}

resource "incus_cluster_group_assignment" "incus_dev_1" {
  cluster_group = incus_cluster_group.amd64.name
  member        = "incus-dev-1"
}
```