### PR TITLE
bugfix: fix interface sort order

### DIFF
--- a/internal/network/resource_network_test.go
+++ b/internal/network/resource_network_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/dustinkirkland/golang-petname"
+	petname "github.com/dustinkirkland/golang-petname"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/lxc/terraform-provider-incus/internal/acctest"


### PR DESCRIPTION
This should fix the flake acceptance tests where ipv4 address is not set, e.g. https://github.com/lxc/terraform-provider-incus/actions/runs/11933941679/job/33262025197#step:8:242