### PR TITLE
Improve remote block docs for local unix sockets

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -38,15 +38,14 @@ provider "incus" {
   accept_remote_certificate    = true
 
   remote {
-    name    = "incus-server-1"
-    scheme  = "https"
-    address = "10.1.1.8"
-    token   = "token"
+    name    = "local"
+    scheme  = "unix"
+    address = ""
     default = true
   }
 
   remote {
-    name    = "incus-server-2"
+    name    = "incus-remote"
     scheme  = "https"
     address = "10.1.2.8"
     token   = "token"
@@ -77,7 +76,9 @@ The following arguments are supported:
 
 The `remote` block supports:
 
-* `address` - *Optional* - The address of the Incus remote.
+* `address` - *Optional* - The address of the Incus remote host when `schema` is 
+  set to `https`. If `schema` is `unix` this will be the path to the local unix 
+  socket, or leaving it as an empty string will use the default socket path.
 
 * `default` - *Optional* - Whether this should be the default remote.
 	This remote will then be used when one is not specified in a resource.


### PR DESCRIPTION
I was confused when trying to define the remote block for the incus host I want Terraform/OpenTofu to talk to and was using variables to set the values for the remote. While the arguments are optional and some of the defaults are stated I found that the `schema` value can change how the `address` argument is used. When the arguments are not present they will use a default value, but I needed the same behavior when an argument was present and contained a value.

I thought it might be useful to provide both an example of a defined local connection to a UNIX socket and a connection to a remote Incus host that would connect over HTTPS.

I also provided a suggestion for updating the description on the `address` field to indicate how the fields value changes when `schema` is set to `unix`.