### PR TITLE
provider-config: Check if unix.socket.user is writable when INCUS_DIR is set

### DIFF
--- a/internal/provider-config/config.go
+++ b/internal/provider-config/config.go
@@ -412,6 +412,11 @@ func determineIncusDir() (string, error) {
 			return incusDir, nil
 		}
 
+		userSocketPath := filepath.Join(incusDir, "unix.socket.user")
+		if utils.IsSocketWritable(userSocketPath) {
+			return incusDir, nil
+		}
+
 		return "", fmt.Errorf("Environment variable INCUS_DIR points to an Incus directory that does not contain a writable unix socket")
 	}
 


### PR DESCRIPTION
This pull request fixes https://github.com/lxc/terraform-provider-incus/issues/200.

---

When running this provider, we set the `INCUS_DIR` environment variable at one point in the config: https://github.com/lxc/terraform-provider-incus/blob/0fbc28b57ffc6b0acbeae63408d646f9c78c2b7e/internal/provider-config/config.go#L165

To ensure that `unix.socket.user` is writable when `INCUS_DIR` is set, we must validate this too properly.