### PR TITLE
network: Add network as computed key

### DIFF
--- a/internal/network/resource_network.go
+++ b/internal/network/resource_network.go
@@ -351,6 +351,7 @@ func (_ NetworkModel) ComputedKeys() []string {
 		"ipv4.nat",
 		"ipv6.address",
 		"ipv6.nat",
+		"network",
 		"volatile.",
 	}
 }


### PR DESCRIPTION
This pull request fixes: https://github.com/lxc/terraform-provider-incus/issues/202

---

When a new OVN network is created in a project with a restricted network uplink, then the Incus server sets the network property that we need to accept in the returned state.