### PR TITLE
network: Set proper default values in network load-balancer

### DIFF
--- a/internal/network/resource_network_lb.go
+++ b/internal/network/resource_network_lb.go
@@ -121,6 +121,8 @@ func (r IncusNetworkLBResource) Schema(_ context.Context, _ resource.SchemaReque
 
 						"target_port": schema.StringAttribute{
 							Optional:    true,
+							Computed:    true,
+							Default:     stringdefault.StaticString(""),
 							Description: "LB backend target port",
 						},
 					},
@@ -133,6 +135,8 @@ func (r IncusNetworkLBResource) Schema(_ context.Context, _ resource.SchemaReque
 					Attributes: map[string]schema.Attribute{
 						"description": schema.StringAttribute{
 							Optional:    true,
+							Computed:    true,
+							Default:     stringdefault.StaticString(""),
 							Description: "Port description",
 						},
 

--- a/internal/network/resource_network_lb_test.go
+++ b/internal/network/resource_network_lb_test.go
@@ -118,55 +118,6 @@ func TestAccNetworkLB_withBackend(t *testing.T) {
 	})
 }
 
-func TestAccNetworkLB_withBackendButWithoutDescription(t *testing.T) {
-	instanceName := petname.Generate(2, "")
-
-	backend := api.NetworkLoadBalancerBackend{
-		Name:          "backend",
-		TargetAddress: "10.0.0.2",
-		TargetPort:    "80",
-	}
-
-	port := api.NetworkLoadBalancerPort{
-		Description: "Port 8080/tcp",
-		Protocol:    "tcp",
-		ListenPort:  "8080",
-	}
-
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.PreCheck(t)
-			acctest.PreCheckAPIExtensions(t, "network_load_balancer")
-		},
-		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccNetworkLB_withBackendAndPortButWithoutDescription(instanceName, backend, port),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("incus_network.ovnbr", "name", "ovnbr"),
-					resource.TestCheckResourceAttr("incus_network.ovn", "name", "ovn"),
-					resource.TestCheckResourceAttr("incus_network_lb.test", "network", "ovn"),
-					resource.TestCheckResourceAttr("incus_network_lb.test", "listen_address", "10.10.10.200"),
-					resource.TestCheckResourceAttr("incus_network_lb.test", "backend.#", "1"),
-					resource.TestCheckResourceAttr("incus_network_lb.test", "backend.0.name", backend.Name),
-					resource.TestCheckResourceAttr("incus_network_lb.test", "backend.0.description", ""),
-					resource.TestCheckResourceAttr("incus_network_lb.test", "backend.0.target_address", backend.TargetAddress),
-					resource.TestCheckResourceAttr("incus_network_lb.test", "backend.0.target_port", backend.TargetPort),
-					resource.TestCheckResourceAttr("incus_network_lb.test", "port.#", "1"),
-					resource.TestCheckResourceAttr("incus_network_lb.test", "port.0.description", port.Description),
-					resource.TestCheckResourceAttr("incus_network_lb.test", "port.0.protocol", port.Protocol),
-					resource.TestCheckResourceAttr("incus_network_lb.test", "port.0.listen_port", port.ListenPort),
-					resource.TestCheckResourceAttr("incus_network_lb.test", "port.0.target_backend.#", "1"),
-					resource.TestCheckResourceAttr("incus_network_lb.test", "port.0.target_backend.0", backend.Name),
-					resource.TestCheckResourceAttr("incus_instance.instance", "name", instanceName),
-					resource.TestCheckResourceAttr("incus_instance.instance", "status", "Running"),
-					resource.TestCheckResourceAttr("incus_instance.instance", "ipv4_address", backend.TargetAddress),
-				),
-			},
-		},
-	})
-}
-
 func testAccNetworkLB_basic() string {
 	lbRes := `
 resource "incus_network_lb" "test" {
@@ -284,55 +235,4 @@ resource "incus_network" "ovn" {
   }
 }
 `
-}
-
-func testAccNetworkLB_withBackendAndPortButWithoutDescription(instanceName string, backend api.NetworkLoadBalancerBackend, port api.NetworkLoadBalancerPort) string {
-	args := []any{
-		instanceName,          // 1
-		acctest.TestImage,     // 2
-		backend.Name,          // 3
-		backend.TargetAddress, // 4
-		backend.TargetPort,    // 5
-		port.Description,      // 6
-		port.Protocol,         // 7
-		port.ListenPort,       // 8
-	}
-
-	lbRes := fmt.Sprintf(`
-resource "incus_instance" "instance" {
-  name      = "%[1]s"
-  image     = "%[2]s"
-  ephemeral = false
-
-  device {
-    name = "eth0"
-    type = "nic"
-    properties = {
-      "network"      = incus_network.ovn.name
-      "ipv4.address" = "%[4]s"
-    }
-  }
-}
-
-resource "incus_network_lb" "test" {
-  network        = incus_network.ovn.name
-  listen_address = "10.10.10.200"
-  description    = "Load Balancer with Backend and Port"
-
-  backend {
-    name           = "%[3]s"
-    target_address = "%[4]s"
-    target_port    = "%[5]s"
-  }
-
-  port {
-    description    = "%[6]s"
-    protocol       = "%[7]s"
-    listen_port    = "%[8]s"
-    target_backend = ["%[3]s"]
-  }
-}
-`, args...)
-
-	return fmt.Sprintf("%s\n%s", ovnNetworkResource(), lbRes)
 }


### PR DESCRIPTION
This pull request fixes: https://github.com/lxc/terraform-provider-incus/issues/196

---

`backend.target_port` and `port.description` are computed string values that require proper default values to avoid inconsistent results after apply.