### PR TITLE
New `wait_for` configuration block for instance resource

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,34 @@
+# Testing
+
+## Setting up VSCode to run tests locally
+
+To set up VSCode to run the tests locally, follow these steps:
+
+1. Create a `.vscode` directory in the root of your project if it doesn't already exist.
+2. Inside the `.vscode` directory, create a `settings.json` file.
+3. Add the following configuration to the `settings.json` file:
+
+   ```json
+   {
+     "go.testTimeout": "300s",
+     "go.testEnvVars": {
+       "TF_ACC": "1"
+     }
+   }
+   ```
+
+This configuration will enable verbose test output, set a test timeout of 30 seconds, run tests on save, and set the necessary environment variables for acceptance tests.
+
+### Using a different Incus Remote
+
+Add `INCUS_REMOTE` to `go.testEnvVars` to use a different Incus Remote instead of `local`.
+
+```json
+{
+  "go.testTimeout": "300s",
+  "go.testEnvVars": {
+    "TF_ACC": "1",
+    "INCUS_REMOTE": "incus-dev"
+  }
+}
+```

--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -123,6 +123,85 @@ resource "incus_instance" "instance1" {
 }
 ```
 
+## Example of waiting for the Incus agent in a virtual machine
+
+```hcl
+resource "incus_instance" "instance1" {
+  project = "default"
+  name    = "instance1"
+  image   = "images:debian/12"
+  type    = "virtual-machine"
+
+  wait_for {
+    type = "agent"
+  }
+}
+```
+
+## Example of waiting for a certain time period
+
+```hcl
+resource "incus_instance" "instance1" {
+  project = "default"
+  name    = "instance1"
+  image   = "images:debian/12"
+
+  wait_for {
+    type = "delay"
+    delay = "30s"
+  }
+}
+```
+
+## Example of waiting for the IPv4 network to be ready
+
+```hcl
+resource "incus_instance" "instance1" {
+  project = "default"
+  name    = "instance1"
+  image   = "images:debian/12"
+
+  wait_for {
+    type = "ipv4"
+  }
+}
+```
+
+## Example of waiting for the IPv6 network to be ready on a specific network interface
+
+```hcl
+resource "incus_instance" "instance1" {
+  project = "default"
+  name    = "instance1"
+  image   = "images:debian/12"
+
+  wait_for {
+    type = "ipv6"
+    nic  = "eth0"
+  }
+}
+```
+
+## Example of waiting for the IPv4 and IPv6 network to be ready on a specific network interface
+
+```hcl
+resource "incus_instance" "instance1" {
+  project = "default"
+  name    = "instance1"
+  image   = "images:debian/12"
+
+  wait_for {
+    type = "ipv4"
+    type = "eth0"
+  }
+
+  wait_for {
+    type = "ipv6"
+    type = "etho"
+  }
+}
+```
+
 ## Argument Reference
 
 * `name` - **Required** - Name of the instance.
@@ -136,14 +215,14 @@ resource "incus_instance" "instance1" {
 
 * `description` - *Optional* - Description of the instance.
 
-* `type` - *Optional* -  Instance type. Can be `container`, or `virtual-machine`. Defaults to `container`.
+* `type` - *Optional* - Instance type. Can be `container`, or `virtual-machine`. Defaults to `container`.
 
 * `ephemeral` - *Optional* - Boolean indicating if this instance is ephemeral. Defaults to `false`.
 
 * `running` - *Optional* - Boolean indicating whether the instance should be started (running). Defaults to `true`.
 
-* `wait_for_network` - *Optional* - Boolean indicating if the provider should wait for the instance to get an IPv4 address before considering the instance as started.
-  If `running` is set to false or instance is already running (on update), this value has no effect. Defaults to `true`.
+* `wait_for` - *Optional* - WaitFor definition. See reference below.
+  If `running` is set to false or instance is already running (on update), this value has no effect.
 
 * `profiles` - *Optional* - List of Incus config profiles to apply to the new
   instance. Profile `default` will be applied if profiles are not set (are `null`).
@@ -170,6 +249,14 @@ The `source_instance` block supports:
 * `name` - **Required** - Name of the source instance.
 
 * `snapshot`- *Optional* - Name of the snapshot of the source instance
+
+The `wait_for` block supports:
+
+* `type` - **Required** - Type for what should be waited for. Can be `agent`, `delay`, `ipv4`, `ipv6` or `ready`.
+
+* `delay` - *Optional* - Delay time that should be waited for when type is `delay`, e.g. `30s`.
+
+* `nic` - *Optional* - Network interface that should be waited for when type is `ipv4` or `ipv6`.
 
 The `device` block supports:
 

--- a/internal/acctest/provider_factory.go
+++ b/internal/acctest/provider_factory.go
@@ -1,6 +1,7 @@
 package acctest
 
 import (
+	"os"
 	"sync"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
@@ -28,7 +29,21 @@ func testProvider() *provider_config.IncusProviderConfig {
 	defer testProviderMutex.Unlock()
 
 	if testProviderConfig == nil {
-		config := incus_config.DefaultConfig()
+		var config *incus_config.Config
+
+		incusRemote := os.Getenv("INCUS_REMOTE")
+		if incusRemote != "" {
+			var err error
+			config, err = incus_config.LoadConfig("")
+			if err != nil {
+				panic(err)
+			}
+
+			config.DefaultRemote = incusRemote
+		} else {
+			config = incus_config.DefaultConfig()
+		}
+
 		acceptClientCert := true
 		testProviderConfig = provider_config.NewIncusProvider(config, acceptClientCert)
 	}

--- a/internal/network/resource_network_test.go
+++ b/internal/network/resource_network_test.go
@@ -348,7 +348,11 @@ resource "incus_network" "eth1" {
 resource "incus_instance" "instance1" {
   name             = "%s"
   image            = "%s"
-  wait_for_network = true
+
+  wait_for {
+    type = "ipv4"
+    nic = "eth0"
+  }
 
   device {
     name = "eth0"
@@ -378,7 +382,6 @@ resource "incus_network" "eth1" {
 resource "incus_instance" "instance1" {
   name             = "%s"
   image            = "%s"
-  wait_for_network = false
 
   device {
     name = "eth0"


### PR DESCRIPTION
This pull request introduces significant changes to the `incus_instance` resource, removing the `wait_for_network` attribute for the new `wait_for` syntax.

The new `wait_for` syntax supports the following types:

- `agent`: Waits for the Incus agent to be responding
- `delay`: Waits for a specific amount of time
- `ipv4`: Waits for the IPv4 network to be ready
- `ipv6`: Waits for an IPv6 network to be ready
- `ready`: Waits for the Incus instance to be ready (Instance State == `READY`)

**Breaking changes:**

- We used to wait for the IPv4 network to be ready by default, but that’s not the case anymore. To revert to this behavior, set the `wait_for` block with type `ipv4`.
- We now wait for an instance to be in the `RUNNING` state instead of also waiting for the Incus agent to be running when starting a virtual machine. 

---

**Example 1: Waiting for the Incus agent in a virtual machine**

```hcl
resource "incus_instance" "u1" {
  name  = "u1"
  image = "images:ubuntu/24.04"
  type = "virtual-machine"

  wait_for {
    type = "agent"
  }
}
```

***Example 2: Waiting for IPv4 and IPv6 network to be responding for specific interfaces***
```hcl
resource "incus_instance" "a1" {
  name  = "a1"
  image = "images:alpine/edge"

  config = {
    "user.access_interface" = "eth0"
  }

  wait_for {
    type = "ipv4"
    nic  = "eth0"
  }

  wait_for {
    type = "ipv6"
    nic  = "eth0"
  }
}
```


