### PR TITLE
instance: Add valiation for pushing files

### DIFF
--- a/internal/instance/resource_instance.go
+++ b/internal/instance/resource_instance.go
@@ -453,6 +453,15 @@ func (r InstanceResource) ValidateConfig(ctx context.Context, req resource.Valid
 			}
 		}
 	}
+
+	if !config.Files.IsNull() {
+		if !config.Running.IsNull() && !config.Running.ValueBool() {
+			resp.Diagnostics.AddError(
+				"Invalid Configuration",
+				"Files can only be pushed to running instances.",
+			)
+		}
+	}
 }
 
 func (r InstanceResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {


### PR DESCRIPTION
The new validation checks that the instance is runnning when files should be pushed to the instance. Otherwise a validation error message is returned, fixes: https://github.com/lxc/terraform-provider-incus/issues/164