### PR TITLE
 Fix running acceptance tests on different distributions when using the socket

### DIFF
--- a/internal/provider-config/config.go
+++ b/internal/provider-config/config.go
@@ -423,6 +423,8 @@ func determineIncusDir() (string, error) {
 	incusSocketPaths := []string{
 		"/var/lib/incus/unix.socket",
 		"/var/lib/incus/unix.socket.user",
+		"/run/incus/unix.socket",
+		"/run/incus/unix.socket.user",
 	}
 
 	// Iterate over incusSocketPaths and find a writable unix socket.


### PR DESCRIPTION
Tested using Fedora, should also work on OpenSUSE and Arch.