### PR TITLE
Instance architecture

### DIFF
--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -242,6 +242,8 @@ resource "incus_instance" "instance1" {
 
 * `target` - *Optional* - Specify a target node in a cluster.
 
+* `architecture` - *Optional* - The instance architecture (e.g. x86_64, aarch64). See [Architectures](https://linuxcontainers.org/incus/docs/main/architectures/) for all possible values.
+
 The `source_instance` block supports:
 
 * `project` - **Required** - Name of the project in which the source instance exists.

--- a/internal/acctest/checks.go
+++ b/internal/acctest/checks.go
@@ -105,6 +105,27 @@ func PreCheckClustering(t *testing.T) {
 	}
 }
 
+func PreCheck_x86_64(t *testing.T) {
+	p := testProvider()
+	server, err := p.InstanceServer("", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	apiServer, _, err := server.GetServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, arch := range apiServer.Environment.Architectures {
+		if arch == "x86_64" {
+			return
+		}
+	}
+
+	t.Skipf("Test %q skipped: Incus server does not support x86_64.", t.Name())
+}
+
 // PrintResourceState is a test check function that prints the entire state
 // of a resource with the given name. This check should be used only for
 // debuging purposes.

--- a/internal/common/schema_validators.go
+++ b/internal/common/schema_validators.go
@@ -1,4 +1,4 @@
-package image
+package common
 
 import (
 	"context"
@@ -9,18 +9,18 @@ import (
 	"github.com/lxc/incus/v6/shared/osarch"
 )
 
-type architectureValidator struct{}
+type ArchitectureValidator struct{}
 
-func (v architectureValidator) Description(ctx context.Context) string {
+func (v ArchitectureValidator) Description(ctx context.Context) string {
 	supportedArchitecturesList := strings.Join(osarch.SupportedArchitectures(), ", ")
 	return fmt.Sprintf("Attribute architecture value must be one of: %s.", supportedArchitecturesList)
 }
 
-func (v architectureValidator) MarkdownDescription(ctx context.Context) string {
+func (v ArchitectureValidator) MarkdownDescription(ctx context.Context) string {
 	return v.Description(ctx)
 }
 
-func (v architectureValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+func (v ArchitectureValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
 	value := req.ConfigValue.ValueString()
 	if value == "" {
 		return

--- a/internal/image/datasource_image.go
+++ b/internal/image/datasource_image.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/lxc/incus/v6/shared/api"
 
+	"github.com/lxc/terraform-provider-incus/internal/common"
 	"github.com/lxc/terraform-provider-incus/internal/errors"
 	provider_config "github.com/lxc/terraform-provider-incus/internal/provider-config"
 )
@@ -63,7 +64,7 @@ func (d *ImageDataSource) Schema(_ context.Context, req datasource.SchemaRequest
 				Optional: true,
 				Computed: true,
 				Validators: []validator.String{
-					architectureValidator{},
+					common.ArchitectureValidator{},
 				},
 			},
 

--- a/internal/image/resource_image.go
+++ b/internal/image/resource_image.go
@@ -30,6 +30,7 @@ import (
 	"github.com/lxc/incus/v6/shared/api"
 	"github.com/lxc/incus/v6/shared/archive"
 
+	"github.com/lxc/terraform-provider-incus/internal/common"
 	"github.com/lxc/terraform-provider-incus/internal/errors"
 	provider_config "github.com/lxc/terraform-provider-incus/internal/provider-config"
 	"github.com/lxc/terraform-provider-incus/internal/utils"
@@ -138,7 +139,7 @@ func (r ImageResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 							stringplanmodifier.RequiresReplace(),
 						},
 						Validators: []validator.String{
-							architectureValidator{},
+							common.ArchitectureValidator{},
 						},
 					},
 					"copy_aliases": schema.BoolAttribute{

--- a/internal/instance/resource_instance_test.go
+++ b/internal/instance/resource_instance_test.go
@@ -55,6 +55,28 @@ func TestAccInstance_noImage(t *testing.T) {
 	})
 }
 
+func TestAccInstance_noImageWithArchitecture(t *testing.T) {
+	instanceName := petname.Generate(2, "-")
+	architecture := "x86_64"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheck_x86_64(t)
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstance_noImageWithArchitecture(instanceName, architecture),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("incus_instance.instance1", "name", instanceName),
+					resource.TestCheckResourceAttr("incus_instance.instance1", "architecture", architecture),
+				),
+			},
+		},
+	})
+}
+
 func TestAccInstance_ephemeral(t *testing.T) {
 	instanceName := petname.Generate(2, "-")
 
@@ -1070,6 +1092,16 @@ resource "incus_instance" "instance1" {
   running = false
 }
 	`, name)
+}
+
+func testAccInstance_noImageWithArchitecture(name string, architecture string) string {
+	return fmt.Sprintf(`
+resource "incus_instance" "instance1" {
+  name         = "%s"
+  architecture = "%s"
+  running      = false
+}
+	`, name, architecture)
 }
 
 func testAccInstance_ephemeral(name string) string {


### PR DESCRIPTION
This pull request adds support for specifying an architecture when creating an empty instance (fixes: #218). It also ensures that the architecture is set and accessible for instances created from images, source files, or other instances.

**Example:**

```hcl
resource "incus_instance" "a1" {
  name         = "a1"
  architecture = "x86_64"
  running      = false
}
```

The architecture attribute is now available for use in output variables too:

```hcl
resource "incus_instance" "a1" {
  name         = "a1"
  architecture = "x86_64"
  running      = false
}

resource "incus_instance" "a2" {
  name    = "a2"
  image   = "images:alpine/edge"
  running = false
}

output "a1_arch" {
  value = incus_instance.a1.architecture
}

output "a2_arch" {
  value = incus_instance.a2.architecture
}
```