### PR TITLE
Implement incus image alias nested block

### DIFF
--- a/docs/resources/image.md
+++ b/docs/resources/image.md
@@ -19,6 +19,28 @@ resource "incus_instance" "test1" {
 }
 ```
 
+## Image alias Example
+
+```hcl
+resource "incus_image" "alpine" {
+  source_image = {
+    remote = "images"
+    name   = "alpine/edge"
+  }
+
+  alias {
+    name        = "alpine"
+    description = "Alpine Linux"
+  }
+
+  alias {
+    name        = "alpine-edge"
+    description = "Alpine Linux Edge"
+  }
+}
+
+```
+
 ## Argument Reference
 
 * `source_file` - *Optional* - The image file from the local file system from which the image will be created. See reference below.
@@ -26,9 +48,6 @@ resource "incus_instance" "test1" {
 * `source_image` - *Optional* - The source image from which the image will be created. See reference below.
 
 * `source_instance` - *Optional* - The source instance from which the image will be created. See reference below.
-
-* `aliases` - *Optional* - A list of aliases to assign to the image after
-  pulling.
 
 * `project` - *Optional* - Name of the project where the image will be stored.
 
@@ -62,6 +81,11 @@ The `source_instance` block supports:
 * `name` - **Required** - Name of the source instance.
 
 * `snapshot`- *Optional* - Name of the snapshot of the source instance
+
+The `alias` block supports:
+
+* `name` - **Required** - The name of the alias.
+* `description` - *Optional* - A description for the alias.
 
 ## Attribute Reference
 


### PR DESCRIPTION
## Description

This pull request implements the `incus_image_alias` resource.

close #221 

- [x] source code
- [x] document
- [x] test case

## Example

**Terraform Configuration**
```
resource "incus_image" "img" {
  source_image = {
    remote = "images"
    name   = "alpine/edge"
  }

  alias {
    name        = "alpine"
    description = "Alpine Linux"
  }

  alias {
    name        = "alpine-edge"
    description = "Alpine Linux Edge"
  }
}
```