### PR TITLE
network: Force network ACL recreation when name was changed

### DIFF
--- a/internal/network/resource_network_acl.go
+++ b/internal/network/resource_network_acl.go
@@ -69,6 +69,9 @@ func (r *NetworkAclResource) Schema(_ context.Context, _ resource.SchemaRequest,
 		Attributes: map[string]schema.Attribute{
 			"name": schema.StringAttribute{
 				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"description": schema.StringAttribute{
 				Optional: true,


### PR DESCRIPTION
This pull request addresses the issue where the name of an `incus_network_acl` resource is modified which currently leads to the following issue:

```hcl
$ tofu apply

incus_network_acl.this: Refreshing state... [name=my-acl]

OpenTofu used the selected providers to generate the following execution plan.
Resource actions are indicated with the following symbols:
  ~ update in-place

OpenTofu will perform the following actions:

  # incus_network_acl.this will be updated in-place
  ~ resource "incus_network_acl" "this" {
      ~ name        = "my-acl" -> "my-acld"
        # (2 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  OpenTofu will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

incus_network_acl.this: Modifying... [name=my-acl]
╷
│ Error: Failed to retrieve existing network ACL "my-acld"
│ 
│   with incus_network_acl.this,
│   on fix-network-acl-rename.tf line 2, in resource "incus_network_acl" "this":
│    2: resource "incus_network_acl" "this" {
│ 
│ Network ACL not found
╵
```

With the new changes, the `incus_network_acl` resource will be recreated when the name is changed:

```hcl
$ tofu apply

incus_network_acl.this: Refreshing state... [name=my-acl]

OpenTofu used the selected providers to generate the following execution plan.
Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

OpenTofu will perform the following actions:

  # incus_network_acl.this must be replaced
-/+ resource "incus_network_acl" "this" {
      ~ name        = "my-acl" -> "my-acld" # forces replacement
        # (2 unchanged attributes hidden)
    }

Plan: 1 to add, 0 to change, 1 to destroy.

Do you want to perform these actions?
  OpenTofu will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

incus_network_acl.this: Destroying... [name=my-acl]
incus_network_acl.this: Destruction complete after 0s
incus_network_acl.this: Creating...
incus_network_acl.this: Creation complete after 0s [name=my-acld]

Apply complete! Resources: 1 added, 0 changed, 1 destroyed.
```