### PR TITLE
gitignore: Ignore VSCode configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 dist/
 
-.idea
 **/*.swp
-settings.json
+
+.idea/
+.vscode/
 
 terraform-provider-incus
 terraform-provider-incus.iml


### PR DESCRIPTION
Just like IntellJ-based IDEs, we also ignore all VSCode configurations that are saved in the `.vscode` directory.