### PR TITLE
Fix: Preserve empty string config values in StripConfig

### DIFF
--- a/internal/common/incus_config.go
+++ b/internal/common/incus_config.go
@@ -124,6 +124,10 @@ func StripConfig(resConfig map[string]string, modelConfig types.Map, computedKey
 	for k, v := range usrConfig {
 		if v == nil {
 			config[k] = nil
+		} else if *v == "" {
+			// Preserve empty string values from user config
+			emptyStr := ""
+			config[k] = &emptyStr
 		}
 	}
 

--- a/internal/common/incus_config_test.go
+++ b/internal/common/incus_config_test.go
@@ -1,0 +1,72 @@
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStripConfig_PreservesEmptyStrings(t *testing.T) {
+	// Test that StripConfig preserves empty string values from user config
+	ctx := context.Background()
+
+	// Create user config with empty string values
+	userConfigMap := map[string]*string{
+		"cloud-init.network-config": strPtr(""),
+		"cloud-init.vendor-data":    strPtr(""),
+		"user.user-data":           strPtr(""),
+		"user.test":                strPtr("value"),
+		"user.empty":               strPtr(""),
+		"user.null":                nil,
+	}
+
+	// Convert to types.Map
+	modelConfig, _ := types.MapValueFrom(ctx, types.StringType, userConfigMap)
+
+	// Simulate resource config from API (Incus returns empty strings)
+	resConfig := map[string]string{
+		"cloud-init.network-config": "",
+		"cloud-init.vendor-data":    "",
+		"user.user-data":           "",
+		"user.test":                "value",
+		"user.empty":               "",
+		"volatile.uuid":            "some-uuid", // computed key
+		"image.description":        "Ubuntu",    // computed key
+	}
+
+	// Call StripConfig
+	result := StripConfig(resConfig, modelConfig, []string{"volatile.", "image."})
+
+	// Verify empty strings are preserved
+	assert.NotNil(t, result["cloud-init.network-config"])
+	assert.Equal(t, "", *result["cloud-init.network-config"])
+
+	assert.NotNil(t, result["cloud-init.vendor-data"])
+	assert.Equal(t, "", *result["cloud-init.vendor-data"])
+
+	assert.NotNil(t, result["user.user-data"])
+	assert.Equal(t, "", *result["user.user-data"])
+
+	assert.NotNil(t, result["user.empty"])
+	assert.Equal(t, "", *result["user.empty"])
+
+	// Non-empty value preserved
+	assert.NotNil(t, result["user.test"])
+	assert.Equal(t, "value", *result["user.test"])
+
+	// Null value preserved
+	assert.Nil(t, result["user.null"])
+
+	// Computed keys not included (unless in user config)
+	_, hasVolatile := result["volatile.uuid"]
+	assert.False(t, hasVolatile)
+
+	_, hasImage := result["image.description"]
+	assert.False(t, hasImage)
+}
+
+func strPtr(s string) *string {
+	return &s
+}


### PR DESCRIPTION
## Summary

This PR fixes an issue where instance config fields with empty string values were vanishing after apply, causing "Provider produced inconsistent result after apply" errors.

## Problem

When users set config fields like `cloud-init.network-config`, `cloud-init.vendor-data`, or `user.user-data` to empty strings in their Terraform configuration:

```hcl
config = {
  "cloud-init.network-config" = ""
  "cloud-init.vendor-data"    = ""
  "user.user-data"            = ""
}
```

These fields would disappear from the state after apply, causing Terraform to report inconsistent results.

## Root Cause

The `StripConfig` function in `internal/common/incus_config.go` was not preserving empty string values from user configuration. When reading back from the Incus API, empty string values were being skipped entirely, causing them to vanish from the Terraform state.

## Solution

Modified the `StripConfig` function to explicitly preserve empty string values that were set by users in their configuration. This ensures that:
- Empty strings set by users are maintained in the state
- The provider produces consistent results after apply
- Users can explicitly set config fields to empty strings when needed

## Testing

- Added unit test `TestStripConfig_PreservesEmptyStrings` to verify the fix
- Test confirms that empty string values from user config are preserved
- Test also verifies that computed keys and null values behave correctly

## Related Issues

This type of issue commonly affects cloud-init and user-data fields where empty strings may be valid configurations.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>