### PR TITLE
Add LINSTOR to the list of storage drivers

### DIFF
--- a/docs/resources/storage_pool.md
+++ b/docs/resources/storage_pool.md
@@ -53,7 +53,7 @@ for more details on how to create a storage pool in clustered mode.
 
 * `name`   - **Required** - Name of the storage pool.
 
-* `driver` - **Required** - Storage Pool driver. Must be one of `dir`, `zfs`, `lvm`, `lvmcluster`, `btrfs`, `ceph`, `cephfs`, or `cephobject`.
+* `driver` - **Required** - Storage Pool driver. Must be one of `dir`, `zfs`, `lvm`, `lvmcluster`, `btrfs`, `ceph`, `cephfs`, `cephobject` or `linstor`.
 
 * `description` - *Optional* - Description of the storage pool.
 
@@ -121,3 +121,11 @@ import {
   * driver == `zfs`
     * `size`
     * `source`
+  * driver == `linstor`
+    * `source`
+    * `linstor.resource_group.name`
+    * `linstor.resource_group.place_count`
+    * `linstor.resource_group.storage_pool`
+    * `linstor.volume.prefix`
+    * `drbd.auto_add_quorum_tiebreaker`
+    * `drbd.on_no_quorum`

--- a/internal/storage/resource_storage_pool.go
+++ b/internal/storage/resource_storage_pool.go
@@ -71,7 +71,7 @@ func (r StoragePoolResource) Schema(_ context.Context, _ resource.SchemaRequest,
 					stringplanmodifier.RequiresReplace(),
 				},
 				Validators: []validator.String{
-					stringvalidator.OneOf("dir", "zfs", "lvm", "lvmcluster", "btrfs", "ceph", "cephfs", "cephobject"),
+					stringvalidator.OneOf("dir", "zfs", "lvm", "lvmcluster", "btrfs", "ceph", "cephfs", "cephobject", "linstor"),
 				},
 			},
 
@@ -369,6 +369,16 @@ func (_ StoragePoolModel) ComputedKeys(driver string) []string {
 		// TODO
 	case "cephobject":
 		// TODO
+	case "linstor":
+		keys = []string{
+			"source",
+			"linstor.resource_group.name",
+			"linstor.resource_group.place_count",
+			"linstor.resource_group.storage_pool",
+			"linstor.volume.prefix",
+			"drbd.auto_add_quorum_tiebreaker",
+			"drbd.on_no_quorum",
+		}
 	}
 
 	return append(keys, "volatile.")


### PR DESCRIPTION
This PR adds LINSTOR support for the resource "storage_pool".
I haven't added resource tests, since there's no LINSTOR environment setup in the github actions (just like for ceph). But let me know if I'm wrong on this.