### PR TITLE
Cluster data source

### DIFF
--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -1,0 +1,95 @@
+# incus_cluster
+
+Provides information about an Incus cluster. This resource supports
+clustered as well as non-clustered (standalone) setups and will treat them
+accordingly. Non-clustered setups will look like a cluster with a single member
+whose name is the empty string (`""`).
+
+## Example Usage
+
+```hcl
+data "incus_cluster" "this" {
+  # No arguments are required.
+}
+```
+
+## Example prevent execution if any server is not online
+
+```hcl
+data "incus_cluster" "this" {
+  remote = "cluster"
+
+  lifecycle {
+    postcondition {
+      condition     = alltrue([for name, member in self.members : member.status == "Online"])
+      error_message = "All servers must be online."
+    }
+  }
+}
+```
+
+## Example create resource for each cluster member
+
+In this example, we define the server configuration `core.bgp_address`, which
+has scope `local`, on each cluster member.
+
+```hcl
+data "incus_cluster" "this" {}
+
+resource "incus_server" "nodes" {
+  for_each = data.incus_cluster.this.members
+
+  target = data.incus_cluster.this.is_clustered ? each.key : null
+
+  config = {
+    "core.bgp_address" = ":179"
+  }
+}
+```
+
+## Argument Reference
+
+* `remote` - *Optional* - The remote for which the Incus cluster information
+  should be queried. If not provided, the provider's default remote will be used.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments
+above:
+
+* `is_clustered` - Whether this is a clustered setup.
+
+* `members`: A map of cluster members. The key is the member name and the value
+  is a member object. For non-clustered setups, the key of the sole member is
+  the empty string (`""`). For the member object see reference below.
+
+The `member` block contains:
+
+* `address` - Address of the cluster member, that is used for cluster communication.
+
+* `architecture` - Architecture of the cluster member (e.g. x86_64, aarch64).
+  See [Architectures](https://linuxcontainers.org/incus/docs/main/architectures/)
+  for all possible values.
+
+* `description` - Description of the cluster member.
+
+* `failure_domain` - Failure domain of the cluster member.
+
+* `groups` - A list of groups the cluster member belongs to.
+
+* `roles` - A list of roles assigned to the cluster member.
+
+* `status` - Status of the cluster member. Possible values are
+  `Online`, `Evacuated`, `Offline`, `Blocked`.
+
+## Notes
+
+* For non-clustered setups, the `members` attribute will contain a single entry
+  with the special key of empty string (`""`).
+  In this case, most of the attributes will be empty, except for `address`,
+  `architecture` and `status`.
+
+  The `address` is taken from the server's `cluster.http_address` config setting
+  and will be set to `https://<address>` if the setting is present, otherwise
+  it will be empty.
+  The `status` will be always set to `Online`.

--- a/internal/acctest/checks.go
+++ b/internal/acctest/checks.go
@@ -105,6 +105,20 @@ func PreCheckClustering(t *testing.T) {
 	}
 }
 
+// PreCheckStandalone skips the test if Incus server is running
+// in clustered mode.
+func PreCheckStandalone(t *testing.T) {
+	p := testProvider()
+	server, err := p.InstanceServer("", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if server.IsClustered() {
+		t.Skipf("Test %q skipped. Incus server is running in clustered mode.", t.Name())
+	}
+}
+
 func PreCheck_x86_64(t *testing.T) {
 	p := testProvider()
 	server, err := p.InstanceServer("", "", "")

--- a/internal/clustering/datasource_cluster.go
+++ b/internal/clustering/datasource_cluster.go
@@ -1,0 +1,247 @@
+package clustering
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/lxc/terraform-provider-incus/internal/errors"
+	provider_config "github.com/lxc/terraform-provider-incus/internal/provider-config"
+)
+
+type ClusterDataSourceModel struct {
+	IsClustered types.Bool   `tfsdk:"is_clustered"`
+	Members     types.Map    `tfsdk:"members"`
+	Remote      types.String `tfsdk:"remote"`
+}
+
+type ClusterDataSource struct {
+	provider *provider_config.IncusProviderConfig
+}
+
+func NewClusterDataSource() datasource.DataSource {
+	return &ClusterDataSource{}
+}
+
+func (d *ClusterDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = fmt.Sprintf("%s_cluster", req.ProviderTypeName)
+}
+
+func (d *ClusterDataSource) Schema(_ context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"is_clustered": schema.BoolAttribute{
+				Computed: true,
+			},
+
+			"members": schema.MapAttribute{
+				Computed: true,
+				ElementType: types.ObjectType{
+					AttrTypes: map[string]attr.Type{
+						"address":        types.StringType,
+						"architecture":   types.StringType,
+						"description":    types.StringType,
+						"failure_domain": types.StringType,
+						"groups": types.ListType{
+							ElemType: types.StringType,
+						},
+						"roles": types.ListType{
+							ElemType: types.StringType,
+						},
+						"status": types.StringType,
+					},
+				},
+			},
+
+			"remote": schema.StringAttribute{
+				Optional: true,
+			},
+		},
+	}
+}
+
+func (d *ClusterDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	data := req.ProviderData
+	if data == nil {
+		return
+	}
+
+	provider, ok := data.(*provider_config.IncusProviderConfig)
+	if !ok {
+		resp.Diagnostics.Append(errors.NewProviderDataTypeError(req.ProviderData))
+		return
+	}
+
+	d.provider = provider
+}
+
+type clusterMemberItem struct {
+	address       string
+	architecture  string
+	description   string
+	failureDomain string
+	groups        []string
+	name          string
+	roles         []string
+	status        string
+}
+
+func (d *ClusterDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var state ClusterDataSourceModel
+
+	diags := req.Config.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	remote := state.Remote.ValueString()
+
+	serverProvider, err := d.provider.InstanceServer(remote, "", "")
+	if err != nil {
+		resp.Diagnostics.Append(errors.NewInstanceServerError(err))
+		return
+	}
+
+	// get cluster environment
+	cluster, _, err := serverProvider.GetCluster()
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to retrieve cluster environment", err.Error())
+		return
+	}
+
+	state.IsClustered = types.BoolValue(cluster.Enabled)
+
+	// fall back if not clustered
+	if !cluster.Enabled {
+		server, _, err := serverProvider.GetServer()
+		if err != nil {
+			resp.Diagnostics.AddError("Failed to retrieve server environment (fall back for non cluster)", err.Error())
+			return
+		}
+
+		// Use `cluster.https_address` as cluster member address, if defined.
+		address, ok := server.Config["cluster.https_address"]
+		if ok {
+			address = fmt.Sprintf("https://%s", address)
+		}
+
+		architecture := server.Environment.KernelArchitecture
+
+		members, diags := toMembersMapType(ctx, []clusterMemberItem{
+			{
+				address:       address,
+				architecture:  architecture,
+				description:   "",
+				failureDomain: "",
+				groups:        []string{},
+				name:          "",
+				roles:         []string{},
+				status:        "Online",
+			},
+		})
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		state.Members = members
+
+		diags = resp.State.Set(ctx, &state)
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+
+	// get cluster members
+	clusterMembers, err := serverProvider.GetClusterMembers()
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to retrieve cluster members", err.Error())
+		return
+	}
+
+	clusterMemberItems := make([]clusterMemberItem, 0, len(clusterMembers))
+
+	for _, clusterMember := range clusterMembers {
+		clusterMemberItems = append(clusterMemberItems, clusterMemberItem{
+			address:       clusterMember.URL,
+			architecture:  clusterMember.Architecture,
+			description:   clusterMember.Description,
+			failureDomain: clusterMember.FailureDomain,
+			groups:        clusterMember.Groups,
+			name:          clusterMember.ServerName,
+			roles:         clusterMember.Roles,
+			status:        clusterMember.Status,
+		})
+	}
+
+	members, diags := toMembersMapType(ctx, clusterMemberItems)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	state.Members = members
+
+	diags = resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+}
+
+func toMembersMapType(ctx context.Context, clusterMemberItems []clusterMemberItem) (types.Map, diag.Diagnostics) {
+	memberObjectType := getMemberObjectType()
+	nilMap := types.MapNull(memberObjectType)
+
+	memberMap := make(map[string]attr.Value, len(clusterMemberItems))
+	for _, clusterMember := range clusterMemberItems {
+		groups, diags := types.ListValueFrom(ctx, types.StringType, clusterMember.groups)
+		if diags.HasError() {
+			return nilMap, diags
+		}
+
+		roles, diags := types.ListValueFrom(ctx, types.StringType, clusterMember.roles)
+		if diags.HasError() {
+			return nilMap, diags
+		}
+
+		memberObjectMap := map[string]attr.Value{
+			"address":        types.StringValue(clusterMember.address),
+			"architecture":   types.StringValue(clusterMember.architecture),
+			"failure_domain": types.StringValue(clusterMember.failureDomain),
+			"description":    types.StringValue(clusterMember.description),
+			"roles":          roles,
+			"groups":         groups,
+			"status":         types.StringValue(clusterMember.status),
+		}
+
+		memberObject, diags := types.ObjectValue(memberObjectType.AttrTypes, memberObjectMap)
+		if diags.HasError() {
+			return nilMap, diags
+		}
+
+		memberMap[clusterMember.name] = memberObject
+	}
+
+	return types.MapValue(memberObjectType, memberMap)
+}
+
+func getMemberObjectType() types.ObjectType {
+	return types.ObjectType{
+		AttrTypes: map[string]attr.Type{
+			"address":        types.StringType,
+			"architecture":   types.StringType,
+			"description":    types.StringType,
+			"failure_domain": types.StringType,
+			"groups": types.ListType{
+				ElemType: types.StringType,
+			},
+			"roles": types.ListType{
+				ElemType: types.StringType,
+			},
+			"status": types.StringType,
+		},
+	}
+}

--- a/internal/clustering/datasource_cluster_test.go
+++ b/internal/clustering/datasource_cluster_test.go
@@ -1,0 +1,69 @@
+package clustering_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	"github.com/lxc/terraform-provider-incus/internal/acctest"
+)
+
+func TestAccClusterDataSource_Standalone(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckStandalone(t)
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `data "incus_cluster" "test" {}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.incus_cluster.test", "is_clustered", "false"),
+					resource.TestCheckResourceAttr("data.incus_cluster.test", "members.%", "1"),
+					// Since the name of the cluster member is the empty string in the
+					// non-clustered case, there are two consecutive dots to address the properties.
+					resource.TestCheckResourceAttr("data.incus_cluster.test", "members..%", "7"),                                                       // Expected attributes per cluster member.
+					resource.TestMatchResourceAttr("data.incus_cluster.test", "members..address", regexp.MustCompile(`(^https://.+:[1-9][0-9]*$|^$)`)), // Expect valid URL or empty string (if Incus is not bound to network and only controlled via unix socket).
+					// Architecture list from https://linuxcontainers.org/incus/docs/main/architectures/
+					resource.TestMatchResourceAttr("data.incus_cluster.test", "members..architecture", regexp.MustCompile(`i686|x86_64|armv6l|armv7l|armv8l|aarch64|ppc|ppc64|ppc64le|s390x|mips|mips64|riscv32|riscv64|loongarch64`)), // Expect architecture to have a supported value
+					resource.TestCheckResourceAttr("data.incus_cluster.test", "members..failure_domain", ""),                                                                                                                           // Failure domain is undefined for standalone instances.
+					resource.TestCheckResourceAttr("data.incus_cluster.test", "members..groups.#", "0"),                                                                                                                                // Cluster member groups are undefined for standalone instances.
+					resource.TestCheckResourceAttr("data.incus_cluster.test", "members..roles.#", "0"),                                                                                                                                 // Cluster member roles are undefined for standalone instances.
+					resource.TestCheckResourceAttr("data.incus_cluster.test", "members..status", "Online"),                                                                                                                             // Standalone instances are always considered online, if fetch data is successful.
+				),
+			},
+		},
+	})
+}
+
+func TestAccClusterDataSource_Clustering(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckClustering(t)
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `data "incus_cluster" "test" {}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.incus_cluster.test", "is_clustered", "true"),
+					resource.TestMatchResourceAttr("data.incus_cluster.test", "members.%", regexp.MustCompile(`^[1-9][0-9]*$`)), // Expect 1 or more cluster members.
+					resource.TestMatchTypeSetElemNestedAttrs("data.incus_cluster.test", "members.*", map[string]*regexp.Regexp{
+						"%":       regexp.MustCompile(`7`),                        // Expected attributes per cluster member.
+						"address": regexp.MustCompile(`^https://.+:[1-9][0-9]*$`), // Expect valid URL.
+						// Architecture list from https://linuxcontainers.org/incus/docs/main/architectures/
+						"architecture":   regexp.MustCompile(`i686|x86_64|armv6l|armv7l|armv8l|aarch64|ppc|ppc64|ppc64le|s390x|mips|mips64|riscv32|riscv64|loongarch64`), // Expect architecture to have a supported value.
+						"failure_domain": regexp.MustCompile(`^.+$`),                                                                                                     // Expect non empty string.
+						"groups.#":       regexp.MustCompile(`^[1-9][0-9]*$`),                                                                                            // Expect at least 1 group.
+						"roles.#":        regexp.MustCompile(`^[1-9][0-9]*$`),                                                                                            // Expect at least 1 role.
+						// Status list from https://github.com/lxc/incus/blob/40095bbc23512120e3a3be6d74d94ccb490e4e8e/internal/server/db/node.go#L148-L174
+						"status": regexp.MustCompile(`^Online|Evacuated|Offline|Blocked$`), // Expect status to have a supported value.
+					}),
+				),
+			},
+		},
+	})
+}

--- a/internal/clustering/datasource_cluster_test.go
+++ b/internal/clustering/datasource_cluster_test.go
@@ -21,17 +21,7 @@ func TestAccClusterDataSource_Standalone(t *testing.T) {
 				Config: `data "incus_cluster" "test" {}`,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.incus_cluster.test", "is_clustered", "false"),
-					resource.TestCheckResourceAttr("data.incus_cluster.test", "members.%", "1"),
-					// Since the name of the cluster member is the empty string in the
-					// non-clustered case, there are two consecutive dots to address the properties.
-					resource.TestCheckResourceAttr("data.incus_cluster.test", "members..%", "7"),                                                       // Expected attributes per cluster member.
-					resource.TestMatchResourceAttr("data.incus_cluster.test", "members..address", regexp.MustCompile(`(^https://.+:[1-9][0-9]*$|^$)`)), // Expect valid URL or empty string (if Incus is not bound to network and only controlled via unix socket).
-					// Architecture list from https://linuxcontainers.org/incus/docs/main/architectures/
-					resource.TestMatchResourceAttr("data.incus_cluster.test", "members..architecture", regexp.MustCompile(`i686|x86_64|armv6l|armv7l|armv8l|aarch64|ppc|ppc64|ppc64le|s390x|mips|mips64|riscv32|riscv64|loongarch64`)), // Expect architecture to have a supported value
-					resource.TestCheckResourceAttr("data.incus_cluster.test", "members..failure_domain", ""),                                                                                                                           // Failure domain is undefined for standalone instances.
-					resource.TestCheckResourceAttr("data.incus_cluster.test", "members..groups.#", "0"),                                                                                                                                // Cluster member groups are undefined for standalone instances.
-					resource.TestCheckResourceAttr("data.incus_cluster.test", "members..roles.#", "0"),                                                                                                                                 // Cluster member roles are undefined for standalone instances.
-					resource.TestCheckResourceAttr("data.incus_cluster.test", "members..status", "Online"),                                                                                                                             // Standalone instances are always considered online, if fetch data is successful.
+					resource.TestCheckResourceAttr("data.incus_cluster.test", "members.%", "0"),
 				),
 			},
 		},

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -292,6 +292,7 @@ func (p *IncusProvider) Resources(_ context.Context) []func() resource.Resource 
 
 func (p *IncusProvider) DataSources(_ context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
+		clustering.NewClusterDataSource,
 		image.NewImageDataSource,
 		profile.NewProfileDataSource,
 		project.NewProjectDataSource,


### PR DESCRIPTION
Replaces #279 and #284.

Example (mainly useful for a clustered Incus setup):

```hcl
terraform {
  required_providers {
    incus = {
      source = "lxc/incus"
    }
  }
}

provider "incus" {}

data "incus_cluster" "this" {
  remote = "cluster"
  lifecycle {
    postcondition {
      condition     = alltrue(self.is_clustered ? [for i, v in self.members : v.status == "Online"] : [])
      error_message = "All servers must be online."
    }
  }
}
```

Resolves: #268 