### PR TITLE
fix: remove running constraint for imageless vm instances

### DIFF
--- a/internal/instance/resource_instance.go
+++ b/internal/instance/resource_instance.go
@@ -660,8 +660,8 @@ func (r InstanceResource) Create(ctx context.Context, req resource.CreateRequest
 		diags = r.createInstanceFromSourceInstance(ctx, server, plan)
 		resp.Diagnostics.Append(diags...)
 	} else {
-		if plan.Running.ValueBool() {
-			resp.Diagnostics.AddError("running must be set to false if the instance is created without image or source_instance", "")
+		if plan.Running.ValueBool() && plan.Type.ValueString() != "virtual-machine" {
+			resp.Diagnostics.AddError("running must be set to false if the instance is created without image or source_instance and not type virtual-machine", "")
 			return
 		}
 


### PR DESCRIPTION
Removes the check that running must be set to false where image or source_image is not set.

Virtual machines start fine when running is true and no image or source_image is set.

Tested locally with:

```hcl
resource "incus_instance" "instance1" {
  name = "instance1"

  type = "virtual-machine"

  running = true

  device {
    name = "cdrom"
    type = "disk"
    properties = {
      pool            = "default"
      source          = "talos-iso"
      readonly        = true
      "boot.priority" = 10
    }
  }

  device {
    name = "nic"
    type = "nic"
    properties = {
      network        = "talos"
      "ipv4.address" = "172.18.0.16"
    }
  }
}
```

```sh
❯ incus list
+-----------+---------+---------------------+------------------------------------------------+-----------------+-----------+
|   NAME    |  STATE  |        IPV4         |                      IPV6                      |      TYPE       | SNAPSHOTS |
+-----------+---------+---------------------+------------------------------------------------+-----------------+-----------+
| instance1 | RUNNING | 172.18.0.16 (nic)   | fd42:5762:cef0:dc9c:1266:6aff:fe5c:88db (eth0) | VIRTUAL-MACHINE | 0         |
|           |         | 10.105.86.53 (eth0) | fc00:db4c:370:56f0:1266:6aff:fe02:ad07 (nic)   |                 |           |
+-----------+---------+---------------------+------------------------------------------------+-----------------+-----------+
```
