### PR TITLE
docs: Use device block in instance backup example

### DIFF
--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -114,7 +114,7 @@ resource "incus_instance" "instance1" {
   name        = "instance1"
   source_file = "/path/to/backup.tar.gz"
 
-  device = {
+  device {
     name = "storage"
     type = "disk"
 


### PR DESCRIPTION
The example for creating an instance from a backup specifies the `device` as an attribute, but it should be a block.

Result of using the current example:

```shell
$ terraform plan
╷
│ Error: Unsupported argument
│
│   on instances.tf line 96, in resource "incus_instance" "instance1":
│   96:   device = {
│
│ An argument named "device" is not expected here. Did you mean to define a block of type "device"?
╵
```
