### PR TITLE
instance: fix false 'files' deployment validation

### DIFF
--- a/internal/instance/resource_instance.go
+++ b/internal/instance/resource_instance.go
@@ -549,16 +549,18 @@ func (r InstanceResource) ValidateConfig(ctx context.Context, req resource.Valid
 		validateWaitFor(ctx, config, resp)
 	}
 
-	if !config.Files.IsNull() {
-		if !config.Running.IsNull() && !config.Running.ValueBool() {
-			resp.Diagnostics.AddError(
-				"Invalid Configuration",
-				"Files can only be pushed to running instances.",
-			)
-		}
+	if !config.Files.IsNull() && !config.Files.IsUnknown() {
+		if len(config.Files.Elements()) > 0 {
+			if !config.Running.IsNull() && !config.Running.ValueBool() {
+				resp.Diagnostics.AddError(
+					"Invalid Configuration",
+					"Files can only be pushed to running instances.",
+				)
+			}
 
-		if config.IsVirtualMachine() {
-			validateWaitForAgentWithFiles(ctx, config, resp)
+			if config.IsVirtualMachine() {
+				validateWaitForAgentWithFiles(ctx, config, resp)
+			}
 		}
 	}
 }


### PR DESCRIPTION
- When using incus_instance with Terraform `for_each` and a dynamic `files` block, combined with passing any value for `running` in the for_each, the check against attempting to push files to a stopped instance fails even when the element in the locals map passed to for_each has no `files` attribute. This is due to the nature of Terraform dynamic blocks, which are not omitted from the resultant resource but rather present as empty maps - checking for null is inappropriate here

```
resource "incus_instance" "container_oci" {
  for_each = local.containers_oci
  name     = each.key
  image    = "docker:${each.value.image_name}:${each.value.image_version}"

  running = try(each.value.running, true)

  profiles = concat(
    try(each.value.profiles, ["main"]),
  )

  config = merge(
    {
      "boot.autostart"   = false
      "limits.cpu"       = 1
      "security.nesting" = false
      "user.app"         = each.key
      "user.env"         = "prod"
    },
    try(each.value.config, {})
  )

  dynamic "device" {
    for_each = try(each.value.devices, {})
    content {
      name       = device.key
      type       = device.value.type
      properties = device.value.properties
    }
  }

  dynamic "file" {
    for_each = try(each.value.files, {})
    content {
      content     = try(file.value.content, null)
      source_path = try(file.value.source_path, null)
      target_path = file.value.target_path
      uid         = file.value.uid
      gid         = file.value.gid
      mode        = file.value.mode
    }
  }

  depends_on = [incus_profile.main]
}
```

Here is an example `local.containers_oci` containing an element that triggers the fault with the current validation code, but doesn't with my PR:

```
locals {
  containers_oci = {
      semaphore = {
        image_name    = "semaphoreui/semaphore"
        image_version = "v2.16.45"
        config = {
          "environment.SEMAPHORE_DB_DIALECT" = "postgres"
          "environment.SEMAPHORE_DB_HOST"    = "postgres.incus"
          "environment.SEMAPHORE_DB_PASS"    = data.azurerm_key_vault_secret.this["postgres_semaphore"].value
          "environment.SEMAPHORE_DB_USER"    = "semaphore"
          # "environment.SEMAPHORE_ADMIN"          = "admin"
          # "environment.SEMAPHORE_ADMIN_EMAIL"    = "admin@localhost"
          # "environment.SEMAPHORE_ADMIN_NAME"     = "admin"
          # "environment.SEMAPHORE_ADMIN_PASSWORD" = "changeme"
        }
        devices = {
          "semaphore_config" = {
            type = "disk"
            properties = {
              path   = "/etc/semaphore"
              pool   = data.incus_storage_pool.local.name
              source = incus_storage_volume.this["semaphore_config"].name
            }
          }
          "semaphore_data" = {
            type = "disk"
            properties = {
              path   = "/var/lib/semaphore"
              pool   = data.incus_storage_pool.local.name
              source = incus_storage_volume.this["semaphore_data"].name
            }
          }
        }
      }
  }
}
```