### PR TITLE
cluster: fix SyncState not checking if the member is part of the group

### DIFF
--- a/internal/cluster/resource_cluster_group_member.go
+++ b/internal/cluster/resource_cluster_group_member.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -236,6 +237,11 @@ func (r *ClusterGroupMemberResource) SyncState(ctx context.Context, tfState *tfs
 	}
 
 	m.ClusterGroup = types.StringValue(clusterGroup.Name)
+
+	if !slices.Contains[[]string, string](clusterGroup.Members, m.Member.ValueString()) {
+		tfState.RemoveResource(ctx)
+		return nil
+	}
 
 	return tfState.Set(ctx, &m)
 }


### PR DESCRIPTION
The SyncState function in `internal/cluster/resource_cluster_group_member.go` what not checking if the member is actually part of the group when refreshing the state from the server. This caused the server to drift from the config and state without any errors or warning.

Because of #272 we probably have a few servers that are not assigned to their group but the provider did not notice it.
With the PR adding multiple members at the same time like in #272 will no longer silently fail:
```
incus_cluster_group.debug: Creating...
incus_cluster_group.debug: Creation complete after 0s [name=debug]
incus_cluster_group_member.debug_m-2: Creating...
incus_cluster_group_member.debug_m-3: Creating...
incus_cluster_group_member.debug_m-3: Creation complete after 0s
╷
│ Error: Missing Resource State After Create
│
│   with incus_cluster_group_member.debug_m-2,
│   on cluster_groups_resources.tf line 65, in resource "incus_cluster_group_member" "debug_m-2":
│   65: resource "incus_cluster_group_member" "debug_m-2" {
│
│ The Terraform Provider unexpectedly returned no resource state after having no errors in the resource creation. This is always an issue in the Terraform Provider and
│ should be reported to the provider developers.
│
│ The resource may have been successfully created, but Terraform is not tracking it. Applying the configuration again with no other action may result in duplicate
│ resource errors. Import the resource if the resource was actually created and Terraform should be tracking it.
╵
```
And running `tofu apply` again will be enough to add the member to its group, as it will be able to detect drift and fix them.