### PR TITLE
storage: fix error on deleting storage volume

### DIFF
--- a/internal/storage/resource_storage_volume.go
+++ b/internal/storage/resource_storage_volume.go
@@ -647,7 +647,7 @@ func (r StorageVolumeResource) Delete(ctx context.Context, req resource.DeleteRe
 	volType := state.Type.ValueString()
 	err = server.DeleteStoragePoolVolume(poolName, volType, volName)
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Failed to remove storage pool %q", poolName), err.Error())
+		resp.Diagnostics.AddError(fmt.Sprintf("Failed to remove storage volume %q", volName), err.Error())
 	}
 }
 


### PR DESCRIPTION
Bug: if removing a storage volume fails, the message printed is scary:

```
# incus_storage_volume.ssh_recorder_state will be destroyed

incus_storage_volume.ssh_recorder_state: Destroying... [name=ssh-recorder-state]
╷
│ Error: Failed to remove storage pool "default"
│ 
│ The storage volume is still in use
╵
```