### PR TITLE
Fix OIDC authentication support in createIncusServerClient

### DIFF
--- a/internal/provider-config/config.go
+++ b/internal/provider-config/config.go
@@ -240,7 +240,7 @@ func (p *IncusProviderConfig) createIncusServerClient(remote IncusProviderRemote
 		return fmt.Errorf("Unable to parse address for remote %q: %v", remote.Name, err)
 	}
 
-	incusRemote := incus_config.Remote{Addr: remote.Address, Protocol: "incus"}
+	incusRemote := incus_config.Remote{Addr: remote.Address, AuthType: remote.AuthenticationType, Protocol: "incus"}
 	p.setIncusConfigRemote(remote.Name, incusRemote)
 
 	if parsedURL.Scheme == "https" || parsedURL.Port() != "" {


### PR DESCRIPTION
I'm trying to use terranix with my incus server with oidc auth:
```nix
{
  terraform.required_providers.incus = {
    source = "lxc/incus";
    version = "1.0.2";
  };
  provider.incus = {
    project = "default";
    default_remote = "starbuck";
    accept_remote_certificate = true;
    generate_client_certificates = false;

    remote = {
      name = "starbuck";
      address = "https://starbuck:8443";
      protocol = "incus";
      authentication_type = "oidc";
    };
  };

  resource.incus_image.my-vm-image = {
    source_file = {
      data_path = "123";
      metadata_path = "123";
    };
  };
}
```

But seems like the client creation doesn't work properly:

```shell
❯ tofu apply -auto-approve

OpenTofu used the selected providers to generate the following execution plan. Resource
actions are indicated with the following symbols:
  + create

OpenTofu will perform the following actions:

  # incus_image.my-vm-image will be created
  + resource "incus_image" "my-vm-image" {
      + copied_aliases = (known after apply)
      + created_at     = (known after apply)
      + fingerprint    = (known after apply)
      + resource_id    = (known after apply)
      + source_file    = {
          + data_path     = "123"
          + metadata_path = "123"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
incus_image.my-vm-image: Creating...
╷
│ Error: Failed to retrieve Incus InstanceServer
│
│   with incus_image.my-vm-image,
│   on config.tf.json line 23, in resource.incus_image.my-vm-image:
│   23:       }
│
│ Unable to create Incus Server client for remote "starbuck": Unable to authenticate with
│ remote server: not authorized
╵
```