### PR TITLE
instance: Persist state before wait_for failures during create

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,9 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
+      - uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_wrapper: false
 
       - name: Setup Incus from ${{ matrix.incus-version }} repository
         run: |

--- a/internal/instance/resource_instance.go
+++ b/internal/instance/resource_instance.go
@@ -750,9 +750,9 @@ func (r InstanceResource) Create(ctx context.Context, req resource.CreateRequest
 
 	instanceName := plan.Name.ValueString()
 
-	// Partially update state, to make terraform aware of
-	// an existing instance.
-	diags = resp.State.SetAttribute(ctx, path.Root("name"), instanceName)
+	// Update Terraform state early to ensure the instance can still be
+	// reconciled or destroyed if subsequent wait operations fail.
+	diags = r.SyncState(ctx, &resp.State, server, plan)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return

--- a/internal/instance/resource_instance_test.go
+++ b/internal/instance/resource_instance_test.go
@@ -265,6 +265,33 @@ func TestAccInstance_execTimeout(t *testing.T) {
 	})
 }
 
+func TestAccInstance_waitForFailureKeepsStateInProject(t *testing.T) {
+	projectName := petname.Generate(2, "-")
+	instanceName := petname.Generate(2, "-")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccInstance_waitForDelayInProject(projectName, instanceName, "not-a-duration"),
+				ExpectError: regexp.MustCompile("Failed to wait for instance"),
+			},
+			{
+				Config: testAccInstance_waitForDelayInProject(projectName, instanceName, "1s"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("incus_project.project1", "name", projectName),
+					resource.TestCheckResourceAttr("incus_instance.instance1", "name", instanceName),
+					resource.TestCheckResourceAttr("incus_instance.instance1", "project", projectName),
+					resource.TestCheckResourceAttr("incus_instance.instance1", "status", "Running"),
+					resource.TestCheckResourceAttr("incus_instance.instance1", "wait_for.0.type", "delay"),
+					resource.TestCheckResourceAttr("incus_instance.instance1", "wait_for.0.delay", "1s"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccInstance_container(t *testing.T) {
 	instanceName := petname.Generate(2, "-")
 
@@ -2148,6 +2175,32 @@ resource "incus_instance" "instance1" {
 	}
 }
 	`, name, acctest.TestImage, delay)
+}
+
+func testAccInstance_waitForDelayInProject(projectName, instanceName, delay string) string {
+	return fmt.Sprintf(`
+resource "incus_project" "project1" {
+  name          = "%s"
+  description   = "Terraform provider test project"
+  force_destroy = true
+
+  config = {
+	"features.images"   = true
+	"features.profiles" = false
+  }
+}
+
+resource "incus_instance" "instance1" {
+  name    = "%s"
+  image   = "%s"
+  project = incus_project.project1.name
+
+	wait_for {
+		type  = "delay"
+		delay = "%s"
+	}
+}
+	`, projectName, instanceName, acctest.TestImage, delay)
 }
 
 func testAccInstance_waitForIPv4(networkName, instanceName string) string {


### PR DESCRIPTION
This pull request fixes https://github.com/lxc/terraform-provider-incus/issues/174.

When an instance is created successfully but a subsequent  `wait_for` step fails, the provider now syncs state immediately after creation so Terraform can still track, destroy, or reconcile the instance on the next run.

---

I also had to add the Terraform Setup action for the `Test` step to fix the following error:

```bash
cannot run Terraform provider tests: failed to find or install Terraform CLI from [0xc00036b6c0 0xc0003846c0]: 
unable to verify checksums signature: openpgp: key expired`
```

Probably due to: https://discuss.hashicorp.com/t/hcsec-2026-03-hashicorp-gpg-key-72d7468f-update/77237