### PR TITLE
Ignore null device properties 

### DIFF
--- a/internal/common/incus_device.go
+++ b/internal/common/incus_device.go
@@ -28,20 +28,16 @@ func ToDeviceMap(ctx context.Context, deviceSet types.Set) (map[string]map[strin
 
 	devices := make(map[string]map[string]string, len(deviceList))
 	for _, d := range deviceList {
-		devName := d.Name.ValueString()
-		devType := d.Type.ValueString()
+		deviceName := d.Name.ValueString()
+		deviceType := d.Type.ValueString()
 
-		// Convert properties into map[string]string.
-		device := make(map[string]string, len(d.Properties.Elements()))
-		if !d.Properties.IsNull() && !d.Properties.IsUnknown() {
-			diags := d.Properties.ElementsAs(ctx, &device, false)
-			if diags.HasError() {
-				return nil, diags
-			}
+		device, diags := ToConfigMap(ctx, d.Properties)
+		if diags.HasError() {
+			return nil, diags
 		}
 
-		device["type"] = devType
-		devices[devName] = device
+		device["type"] = deviceType
+		devices[deviceName] = device
 	}
 
 	return devices, nil
@@ -50,42 +46,114 @@ func ToDeviceMap(ctx context.Context, deviceSet types.Set) (map[string]map[strin
 // ToDeviceSetType converts devices from map[string]map[string]string
 // into types.Set.
 func ToDeviceSetType(ctx context.Context, devices map[string]map[string]string) (types.Set, diag.Diagnostics) {
-	deviceType := map[string]attr.Type{
+	return toDeviceSetType(ctx, devices, types.SetNull(types.ObjectType{AttrTypes: deviceType()}), false)
+}
+
+// ToDeviceSetTypePreservingNulls converts devices from map[string]map[string]string
+// into types.Set, preserving null property values from the model when the API
+// omits those properties.
+func ToDeviceSetTypePreservingNulls(ctx context.Context, devices map[string]map[string]string, modelDevices types.Set) (types.Set, diag.Diagnostics) {
+	return toDeviceSetType(ctx, devices, modelDevices, true)
+}
+
+func deviceType() map[string]attr.Type {
+	return map[string]attr.Type{
 		"name":       types.StringType,
 		"type":       types.StringType,
 		"properties": types.MapType{ElemType: types.StringType},
 	}
+}
 
+func toDeviceSetType(ctx context.Context, devices map[string]map[string]string, modelDevices types.Set, preserveModelNulls bool) (types.Set, diag.Diagnostics) {
+	deviceType := deviceType()
 	nilSet := types.SetNull(types.ObjectType{AttrTypes: deviceType})
 
 	if len(devices) == 0 {
 		return nilSet, nil
 	}
 
+	modelDeviceProperties := map[string]map[string]*string{}
+	if preserveModelNulls {
+		var diags diag.Diagnostics
+		modelDeviceProperties, diags = deviceModelPropertiesByName(ctx, modelDevices)
+		if diags.HasError() {
+			return nilSet, diags
+		}
+	}
+
 	deviceList := make([]DeviceModel, 0, len(devices))
 	for key := range devices {
-		props := devices[key]
+		properties := devices[key]
 
-		devName := types.StringValue(key)
-		devType := types.StringValue(props["type"])
+		deviceName := types.StringValue(key)
+		deviceType := types.StringValue(properties["type"])
 
-		// Remove type from properties, as we manage it
-		// outside properties.
-		delete(props, "type")
+		deviceProperties := make(map[string]*string, len(properties))
+		for k, v := range properties {
+			// Remove type from properties, as we manage it
+			// outside properties.
+			if k == "type" {
+				continue
+			}
 
-		devProps, diags := types.MapValueFrom(ctx, types.StringType, props)
+			v := v
+			deviceProperties[k] = &v
+		}
+
+		if preserveModelNulls {
+			for k, v := range modelDeviceProperties[key] {
+				if v != nil {
+					continue
+				}
+
+				if _, ok := deviceProperties[k]; !ok {
+					deviceProperties[k] = nil
+				}
+			}
+		}
+
+		deviceModelProperties, diags := types.MapValueFrom(ctx, types.StringType, deviceProperties)
 		if diags.HasError() {
 			return nilSet, diags
 		}
 
 		dev := DeviceModel{
-			Name:       devName,
-			Type:       devType,
-			Properties: devProps,
+			Name:       deviceName,
+			Type:       deviceType,
+			Properties: deviceModelProperties,
 		}
 
 		deviceList = append(deviceList, dev)
 	}
 
 	return types.SetValueFrom(ctx, types.ObjectType{AttrTypes: deviceType}, deviceList)
+}
+
+func deviceModelPropertiesByName(ctx context.Context, modelDevices types.Set) (map[string]map[string]*string, diag.Diagnostics) {
+	modelDeviceProperties := map[string]map[string]*string{}
+	if modelDevices.IsNull() || modelDevices.IsUnknown() {
+		return modelDeviceProperties, nil
+	}
+
+	deviceList := make([]DeviceModel, 0, len(modelDevices.Elements()))
+	diags := modelDevices.ElementsAs(ctx, &deviceList, false)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	for _, d := range deviceList {
+		if d.Name.IsNull() || d.Name.IsUnknown() || d.Properties.IsNull() || d.Properties.IsUnknown() {
+			continue
+		}
+
+		properties := make(map[string]*string, len(d.Properties.Elements()))
+		diags := d.Properties.ElementsAs(ctx, &properties, false)
+		if diags.HasError() {
+			return nil, diags
+		}
+
+		modelDeviceProperties[d.Name.ValueString()] = properties
+	}
+
+	return modelDeviceProperties, nil
 }

--- a/internal/common/incus_device_test.go
+++ b/internal/common/incus_device_test.go
@@ -1,0 +1,116 @@
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToDeviceMap_skipsNullProperties(t *testing.T) {
+	ctx := context.Background()
+	devices := mustDeviceSet(ctx, []DeviceModel{
+		{
+			Name: types.StringValue("eth0"),
+			Type: types.StringValue("nic"),
+			Properties: types.MapValueMust(types.StringType, map[string]attr.Value{
+				"nictype": types.StringValue("bridged"),
+				"parent":  types.StringValue("br0"),
+				"hwaddr":  types.StringNull(),
+			}),
+		},
+	})
+
+	actual, diags := ToDeviceMap(ctx, devices)
+	require.False(t, diags.HasError(), diags.Errors())
+
+	assert.Equal(t, map[string]map[string]string{
+		"eth0": {
+			"type":    "nic",
+			"nictype": "bridged",
+			"parent":  "br0",
+		},
+	}, actual)
+}
+
+func TestToDeviceSetTypePreservingNulls_preservesNullProperties(t *testing.T) {
+	ctx := context.Background()
+	modelDevices := mustDeviceSet(ctx, []DeviceModel{
+		{
+			Name: types.StringValue("eth0"),
+			Type: types.StringValue("nic"),
+			Properties: types.MapValueMust(types.StringType, map[string]attr.Value{
+				"nictype": types.StringValue("bridged"),
+				"parent":  types.StringValue("br0"),
+				"hwaddr":  types.StringNull(),
+			}),
+		},
+	})
+
+	actual, diags := ToDeviceSetTypePreservingNulls(ctx, map[string]map[string]string{
+		"eth0": {
+			"type":    "nic",
+			"nictype": "bridged",
+			"parent":  "br0",
+		},
+	}, modelDevices)
+	require.False(t, diags.HasError(), diags.Errors())
+
+	device := singleDevice(t, ctx, actual)
+	props := map[string]*string{}
+	diags = device.Properties.ElementsAs(ctx, &props, false)
+	require.False(t, diags.HasError(), diags.Errors())
+
+	assert.Equal(t, "eth0", device.Name.ValueString())
+	assert.Equal(t, "nic", device.Type.ValueString())
+	assert.Equal(t, "bridged", *props["nictype"])
+	assert.Equal(t, "br0", *props["parent"])
+	assert.Contains(t, props, "hwaddr")
+	assert.Nil(t, props["hwaddr"])
+	assert.NotContains(t, props, "type")
+}
+
+func TestToDeviceSetType_doesNotPreserveNullProperties(t *testing.T) {
+	ctx := context.Background()
+
+	actual, diags := ToDeviceSetType(ctx, map[string]map[string]string{
+		"eth0": {
+			"type":    "nic",
+			"nictype": "bridged",
+			"parent":  "br0",
+		},
+	})
+	require.False(t, diags.HasError(), diags.Errors())
+
+	device := singleDevice(t, ctx, actual)
+	props := map[string]*string{}
+	diags = device.Properties.ElementsAs(ctx, &props, false)
+	require.False(t, diags.HasError(), diags.Errors())
+
+	assert.NotContains(t, props, "hwaddr")
+	assert.NotContains(t, props, "type")
+}
+
+func mustDeviceSet(ctx context.Context, devices []DeviceModel) types.Set {
+	deviceSet, diags := types.SetValueFrom(ctx, types.ObjectType{AttrTypes: deviceType()}, devices)
+	if diags.HasError() {
+		panic(diags.Errors())
+	}
+
+	return deviceSet
+}
+
+func singleDevice(t *testing.T, ctx context.Context, devices types.Set) DeviceModel {
+	t.Helper()
+
+	deviceList := make([]DeviceModel, 0, 1)
+	diags := devices.ElementsAs(ctx, &deviceList, false)
+
+	require.False(t, diags.HasError(), diags.Errors())
+	require.Len(t, deviceList, 1)
+
+	return deviceList[0]
+}

--- a/internal/instance/resource_instance.go
+++ b/internal/instance/resource_instance.go
@@ -1345,7 +1345,7 @@ func (r InstanceResource) SyncState(ctx context.Context, tfState *tfsdk.State, s
 	profiles, diags := ToProfileListType(ctx, instance.Profiles)
 	respDiags.Append(diags...)
 
-	devices, diags := common.ToDeviceSetType(ctx, instance.Devices)
+	devices, diags := common.ToDeviceSetTypePreservingNulls(ctx, instance.Devices, m.Devices)
 	respDiags.Append(diags...)
 
 	if respDiags.HasError() {

--- a/internal/instance/resource_instance_test.go
+++ b/internal/instance/resource_instance_test.go
@@ -644,6 +644,34 @@ func TestAccInstance_device(t *testing.T) {
 	})
 }
 
+func TestAccInstance_devicePropertiesNull(t *testing.T) {
+	instanceName := petname.Generate(2, "-")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstance_devicePropertiesNull(instanceName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("incus_instance.instance1", "name", instanceName),
+					resource.TestCheckResourceAttr("incus_instance.instance1", "status", "Running"),
+					resource.TestCheckResourceAttr("incus_instance.instance1", "device.#", "1"),
+					resource.TestCheckResourceAttr("incus_instance.instance1", "device.0.name", "shared"),
+					resource.TestCheckResourceAttr("incus_instance.instance1", "device.0.type", "disk"),
+					resource.TestCheckResourceAttr("incus_instance.instance1", "device.0.properties.source", "/tmp"),
+					resource.TestCheckResourceAttr("incus_instance.instance1", "device.0.properties.path", "/tmp/shared"),
+				),
+			},
+			{
+				Config:             testAccInstance_devicePropertiesNull(instanceName),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
 func TestAccInstance_addDevice(t *testing.T) {
 	instanceName := petname.Generate(2, "-")
 
@@ -1712,6 +1740,30 @@ resource "incus_instance" "instance1" {
     properties = {
       source = "/tmp"
       path   = "/tmp/shared2"
+    }
+  }
+}
+	`, name, acctest.TestImage)
+}
+
+func testAccInstance_devicePropertiesNull(name string) string {
+	return fmt.Sprintf(`
+variable "readonly" {
+  type    = string
+  default = null
+}
+
+resource "incus_instance" "instance1" {
+  name  = "%s"
+  image = "%s"
+
+  device {
+    name = "shared"
+    type = "disk"
+    properties = {
+      source   = "/tmp"
+      path     = "/tmp/shared"
+      readonly = var.readonly
     }
   }
 }

--- a/internal/profile/resource_profile.go
+++ b/internal/profile/resource_profile.go
@@ -391,7 +391,7 @@ func (r ProfileResource) SyncState(ctx context.Context, tfState *tfsdk.State, se
 	config, diags := common.ToConfigMapType(ctx, common.ToNullableConfig(profile.Config), m.Config)
 	respDiags.Append(diags...)
 
-	devices, diags := common.ToDeviceSetType(ctx, profile.Devices)
+	devices, diags := common.ToDeviceSetTypePreservingNulls(ctx, profile.Devices, m.Devices)
 	respDiags.Append(diags...)
 
 	m.Name = types.StringValue(profile.Name)


### PR DESCRIPTION
Skip null device properties in Incus requests while preserving them in state to avoid mismatches after apply.

This pull requests fixes: https://github.com/lxc/terraform-provider-incus/issues/385
