### PR TITLE
Apply updates before starting stopped instances

### DIFF
--- a/internal/instance/resource_instance.go
+++ b/internal/instance/resource_instance.go
@@ -860,8 +860,9 @@ func (r InstanceResource) Read(ctx context.Context, req resource.ReadRequest, re
 }
 
 // Update updates the instance in the following order:
-// - Ensure instance state (stopped/running).
+// - Stop the instance if its desired state is stopped.
 // - Update configuration (config, devices, profiles).
+// - Start the instance if its desired state is running.
 // - Upload files.
 // - Run exec commands.
 func (r InstanceResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
@@ -895,24 +896,8 @@ func (r InstanceResource) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 
-	// First ensure the desired state of the instance (stopped/running).
-	// This ensures we fail fast if instance runs into an issue.
-	if plan.Running.ValueBool() && !isInstanceOperational(*instanceState) {
-		diag := startInstance(ctx, server, instanceName)
-		if diag != nil {
-			resp.Diagnostics.Append(diag)
-			return
-		}
-
-		// If instance is freshly started, we also take the wait for configurations into account.
-		if len(plan.WaitForConfigs.Elements()) > 0 {
-			diags := waitFor(ctx, server, instanceName, plan.WaitForConfigs)
-			if diags != nil {
-				resp.Diagnostics.Append(diags...)
-				return
-			}
-		}
-	} else if !plan.Running.ValueBool() && !isInstanceStopped(*instanceState) {
+	// Stop before applying configuration changes if the desired state is stopped.
+	if !plan.Running.ValueBool() && !isInstanceStopped(*instanceState) {
 		// Stop the instance gracefully.
 		_, diag := stopInstance(ctx, server, instanceName, false)
 		if diag != nil {
@@ -966,6 +951,26 @@ func (r InstanceResource) Update(ctx context.Context, req resource.UpdateRequest
 	if err != nil {
 		resp.Diagnostics.AddError(fmt.Sprintf("Failed to update instance %q", instance.Name), err.Error())
 		return
+	}
+
+	// Start after applying configuration changes if the desired state is running.
+	// Some updates, such as adding a TPM device to a VM, require the instance to
+	// remain stopped while the change is applied.
+	if plan.Running.ValueBool() && !isInstanceOperational(*instanceState) {
+		diag := startInstance(ctx, server, instanceName)
+		if diag != nil {
+			resp.Diagnostics.Append(diag)
+			return
+		}
+
+		// If instance is freshly started, we also take the wait for configurations into account.
+		if len(plan.WaitForConfigs.Elements()) > 0 {
+			diags := waitFor(ctx, server, instanceName, plan.WaitForConfigs)
+			if diags != nil {
+				resp.Diagnostics.Append(diags...)
+				return
+			}
+		}
 	}
 
 	oldFiles, diags := common.ToFileMap(ctx, state.Files)

--- a/internal/instance/resource_instance_test.go
+++ b/internal/instance/resource_instance_test.go
@@ -334,6 +334,45 @@ func TestAccInstance_virtualMachine(t *testing.T) {
 	})
 }
 
+func TestAccInstance_virtualMachineAddTpmWhileStopped(t *testing.T) {
+	instanceName := petname.Generate(2, "-")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckVirtualization(t)
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstance_started(instanceName, "virtual-machine"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("incus_instance.instance1", "name", instanceName),
+					resource.TestCheckResourceAttr("incus_instance.instance1", "type", "virtual-machine"),
+					resource.TestCheckResourceAttr("incus_instance.instance1", "status", "Running"),
+				),
+			},
+			{
+				Config: testAccInstance_stopped(instanceName, "virtual-machine"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("incus_instance.instance1", "status", "Stopped"),
+					resource.TestCheckResourceAttr("incus_instance.instance1", "running", "false"),
+				),
+			},
+			{
+				Config: testAccInstance_virtualMachineWithTpm(instanceName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("incus_instance.instance1", "status", "Running"),
+					resource.TestCheckResourceAttr("incus_instance.instance1", "running", "true"),
+					resource.TestCheckResourceAttr("incus_instance.instance1", "device.#", "1"),
+					resource.TestCheckResourceAttr("incus_instance.instance1", "device.0.name", "tpm"),
+					resource.TestCheckResourceAttr("incus_instance.instance1", "device.0.type", "tpm"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccInstance_virtualMachineNoDevIncus(t *testing.T) {
 	instanceName := petname.Generate(2, "-")
 
@@ -1487,6 +1526,27 @@ resource "incus_instance" "instance1" {
   config = {
     # Alpine images do not support secureboot.
     "security.secureboot" = false
+  }
+}
+	`, name, acctest.TestImage)
+}
+
+func testAccInstance_virtualMachineWithTpm(name string) string {
+	return fmt.Sprintf(`
+resource "incus_instance" "instance1" {
+  name  = "%s"
+  image = "%s"
+  type  = "virtual-machine"
+
+  config = {
+    # Alpine images do not support secureboot.
+    "security.secureboot" = false
+  }
+
+  device {
+    name       = "tpm"
+    type       = "tpm"
+    properties = {}
   }
 }
 	`, name, acctest.TestImage)


### PR DESCRIPTION
This pull request fixes: https://github.com/lxc/terraform-provider-incus/issues/362

---

Some device changes, such as adding a TPM device to a virtual machine, can only be applied while the instance is stopped.

Previously, the provider started the instance before applying configuration and device changes. This meant that the following workflow still failed:

```bash
incus stop alpine-vm
terraform apply
```

The provider now applies configuration and device changes first. If running is true or left unset, the instance is started afterwards.

**Why not apply_stopped**

I decided not to add `apply_stopped` for now, because it would only make sense for instance devices. Profiles do not have a runtime state, so this would make the instance and profile device models drift apart.