### PR TITLE
Keep targeted network config node-specific

### DIFF
--- a/internal/network/resource_network.go
+++ b/internal/network/resource_network.go
@@ -3,6 +3,8 @@ package network
 import (
 	"context"
 	"fmt"
+	"regexp"
+	"slices"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -371,8 +373,13 @@ func (r NetworkResource) SyncState(ctx context.Context, tfState *tfsdk.State, se
 		}
 	}
 
+	resConfig := network.Config
+	if server.IsClustered() && isTargetedNetwork(m) {
+		resConfig = stripClusterWideNetworkConfig(resConfig)
+	}
+
 	// Extract user defined config and merge it with current config state.
-	stateConfig := common.StripConfig(network.Config, m.Config, m.ComputedKeys())
+	stateConfig := common.StripConfig(resConfig, m.Config, m.ComputedKeys())
 
 	// Convert config state into schema type.
 	config, diags := common.ToConfigMapType(ctx, stateConfig, m.Config)
@@ -412,3 +419,40 @@ func (NetworkModel) ComputedKeys() []string {
 		"volatile.",
 	}
 }
+
+// isTargetedNetwork returns true if the network resource is scoped to a target.
+func isTargetedNetwork(m NetworkModel) bool {
+	return !m.Target.IsUnknown() && !m.Target.IsNull() && m.Target.ValueString() != ""
+}
+
+// stripClusterWideNetworkConfig keeps only config keys owned by a targeted clustered network resource.
+func stripClusterWideNetworkConfig(config map[string]string) map[string]string {
+	nodeConfig := make(map[string]string, len(config))
+	for key, value := range config {
+		if isNodeSpecificNetworkConfig(key) {
+			nodeConfig[key] = value
+		}
+	}
+
+	return nodeConfig
+}
+
+// isNodeSpecificNetworkConfig returns true if Incus treats the network config key as node-specific.
+func isNodeSpecificNetworkConfig(key string) bool {
+	if slices.Contains(nodeSpecificNetworkConfigKeys, key) {
+		return true
+	}
+
+	return nodeSpecificNetworkConfigRe.MatchString(key)
+}
+
+// nodeSpecificNetworkConfigKeys lists static network config keys that Incus treats as node-specific.
+var nodeSpecificNetworkConfigKeys = []string{
+	"bgp.ipv4.nexthop",
+	"bgp.ipv6.nexthop",
+	"bridge.external_interfaces",
+	"parent",
+}
+
+// nodeSpecificNetworkConfigRe matches dynamic network config keys that Incus treats as node-specific.
+var nodeSpecificNetworkConfigRe = regexp.MustCompile(`^tunnel\.[^.]+\.(interface|local)$`)

--- a/internal/network/resource_network_config_test.go
+++ b/internal/network/resource_network_config_test.go
@@ -1,0 +1,63 @@
+package network
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNetworkConfig_nodeSpecificKeys(t *testing.T) {
+	tests := []struct {
+		name     string
+		key      string
+		expected bool
+	}{
+		{name: "parent", key: "parent", expected: true},
+		{name: "bridge external interfaces", key: "bridge.external_interfaces", expected: true},
+		{name: "bgp ipv4 nexthop", key: "bgp.ipv4.nexthop", expected: true},
+		{name: "bgp ipv6 nexthop", key: "bgp.ipv6.nexthop", expected: true},
+		{name: "tunnel interface", key: "tunnel.foo.interface", expected: true},
+		{name: "tunnel local", key: "tunnel.foo.local", expected: true},
+		{name: "vlan", key: "vlan", expected: false},
+		{name: "ipv4 address", key: "ipv4.address", expected: false},
+		{name: "tunnel remote", key: "tunnel.foo.remote", expected: false},
+		{name: "nested tunnel interface", key: "tunnel.foo.bar.interface", expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := isNodeSpecificNetworkConfig(tt.key)
+			if actual != tt.expected {
+				t.Fatalf("isNodeSpecificNetworkConfig(%q) = %t, want %t", tt.key, actual, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNetworkConfig_stripClusterWideKeys(t *testing.T) {
+	config := map[string]string{
+		"parent":                     "bond0",
+		"bridge.external_interfaces": "eth0",
+		"bgp.ipv4.nexthop":           "192.0.2.1",
+		"bgp.ipv6.nexthop":           "2001:db8::1",
+		"tunnel.foo.interface":       "eth1",
+		"tunnel.foo.local":           "192.0.2.2",
+		"vlan":                       "400",
+		"ipv4.address":               "10.150.19.1/24",
+		"tunnel.foo.remote":          "192.0.2.3",
+		"tunnel.foo.bar.interface":   "eth2",
+	}
+
+	actual := stripClusterWideNetworkConfig(config)
+	expected := map[string]string{
+		"parent":                     "bond0",
+		"bridge.external_interfaces": "eth0",
+		"bgp.ipv4.nexthop":           "192.0.2.1",
+		"bgp.ipv6.nexthop":           "2001:db8::1",
+		"tunnel.foo.interface":       "eth1",
+		"tunnel.foo.local":           "192.0.2.2",
+	}
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("stripClusterWideNetworkConfig() = %#v, want %#v", actual, expected)
+	}
+}

--- a/internal/network/resource_network_test.go
+++ b/internal/network/resource_network_test.go
@@ -178,12 +178,50 @@ func TestAccNetwork_target(t *testing.T) {
 					resource.TestCheckResourceAttr("incus_network.cluster_network_per_node.0", "name", networkName),
 					resource.TestCheckResourceAttr("incus_network.cluster_network_per_node.0", "description", ""), // Since target and description are mutual exclusive, we expect the default value in the state.
 					resource.TestCheckResourceAttr("incus_network.cluster_network_per_node.0", "config.bridge.external_interfaces", "nosuchint"),
+					resource.TestCheckNoResourceAttr("incus_network.cluster_network_per_node.0", "config.dns.domain"),
 					acctest.TestCheckResourceAttrInLookup("incus_network.cluster_network_per_node.0", "target", clusterMemberNames),
 
 					resource.TestCheckResourceAttr("incus_network.cluster_network", "name", networkName),
 					resource.TestCheckResourceAttr("incus_network.cluster_network", "description", "clustered network description"),
 					resource.TestCheckResourceAttr("incus_network.cluster_network", "type", "bridge"),
 					resource.TestCheckResourceAttr("incus_network.cluster_network", "config.ipv4.address", "10.150.19.1/24"),
+					resource.TestCheckResourceAttr("incus_network.cluster_network", "config.dns.domain", "example.test"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetwork_targetMacvlanVlan(t *testing.T) {
+	networkName := petname.Name()
+
+	clusterMemberNames := make(map[string]struct{}, 10) // It is unlikely, that acceptance tests are executed against clusters > 10 nodes.
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckClustering(t)
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetwork_targetMacvlanVlan(networkName),
+				Check: resource.ComposeTestCheckFunc(
+					// This populates `clusterMemberNames` and therefore needs to be executed before the
+					// check using this information.
+					acctest.TestCheckGetClusterMemberNames(t, "data.incus_cluster.test", clusterMemberNames),
+
+					// Since "count" is used to create the cluster_network_per_node resources, each resource
+					// is created the same, so it should be enough to just test one of them.
+					resource.TestCheckResourceAttr("incus_network.cluster_network_per_node.0", "name", networkName),
+					resource.TestCheckResourceAttr("incus_network.cluster_network_per_node.0", "type", "macvlan"),
+					resource.TestCheckResourceAttr("incus_network.cluster_network_per_node.0", "config.parent", "incusbr0"),
+					resource.TestCheckNoResourceAttr("incus_network.cluster_network_per_node.0", "config.vlan"),
+					acctest.TestCheckResourceAttrInLookup("incus_network.cluster_network_per_node.0", "target", clusterMemberNames),
+
+					resource.TestCheckResourceAttr("incus_network.cluster_network", "name", networkName),
+					resource.TestCheckResourceAttr("incus_network.cluster_network", "type", "macvlan"),
+					resource.TestCheckResourceAttr("incus_network.cluster_network", "config.vlan", "400"),
 				),
 			},
 		},
@@ -446,6 +484,44 @@ resource "incus_network" "cluster_network" {
   description = "clustered network description"
   config = {
     "ipv4.address" = "10.150.19.1/24"
+    "dns.domain"   = "example.test"
+  }
+}
+`, networkName)
+}
+
+func testAccNetwork_targetMacvlanVlan(networkName string) string {
+	return fmt.Sprintf(`
+data "incus_cluster" "test" {}
+
+locals {
+  member_names = [ for k, v in data.incus_cluster.test.members : k ]
+}
+
+resource "incus_network" "cluster_network_per_node" {
+  // Unfortunately, the terraform plugin test framework does not support
+  // "for_each", so we need to use "count" as an alternative.
+  count = length(local.member_names)
+
+  name   = "%[1]s"
+  target = local.member_names[count.index]
+  type   = "macvlan"
+
+  config = {
+    parent = "incusbr0"
+  }
+}
+
+resource "incus_network" "cluster_network" {
+  depends_on = [
+    incus_network.cluster_network_per_node,
+  ]
+
+  name = incus_network.cluster_network_per_node[0].name
+  type = "macvlan"
+
+  config = {
+    vlan = 400
   }
 }
 `, networkName)


### PR DESCRIPTION
This pull request fixes: https://github.com/lxc/terraform-provider-incus/issues/176

When reading a targeted clustered `incus_network`, Incus returns both node-specific and cluster-wide config.

Previously, the provider wrote the full returned config back into the targeted resource state. This caused cluster-wide keys, such as `vlan`, to appear on the per-node resource and Terraform then tried to remove them on the next apply.

The provider now mirrors Incus' node-specific network config classification from `internal/server/db/networks.go` and only keeps node-specific config in state for targeted clustered networks.

This only applies when the server is clustered and `target` is set. Standalone network reads keep the existing behavior.
