### PR TITLE
Add wait_for cloud-init

### DIFF
--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -176,6 +176,20 @@ resource "incus_instance" "instance1" {
 }
 ```
 
+## Example of waiting for cloud-init to complete
+
+```hcl
+resource "incus_instance" "instance1" {
+  project = "default"
+  name    = "instance1"
+  image   = "images:ubuntu/24.04/cloud"
+
+  wait_for {
+    type = "cloud-init"
+  }
+}
+```
+
 ## Example of waiting for a certain time period
 
 ```hcl
@@ -294,7 +308,7 @@ The `source_instance` block supports:
 
 The `wait_for` block supports:
 
-* `type` - **Required** - Type for what should be waited for. Can be `agent`, `delay`, `ipv4`, `ipv6` or `ready`.
+* `type` - **Required** - Type for what should be waited for. Can be `agent`, `cloud-init`, `delay`, `ipv4`, `ipv6` or `ready`.
 
 * `delay` - *Optional* - Delay time that should be waited for when type is `delay`, e.g. `30s`.
 

--- a/internal/instance/resource_instance.go
+++ b/internal/instance/resource_instance.go
@@ -2,6 +2,7 @@ package instance
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"sort"
@@ -103,6 +104,10 @@ func (m WaitForModel) IsIPv6() bool {
 
 func (m WaitForModel) IsReady() bool {
 	return m.Type.ValueString() == "ready"
+}
+
+func (m WaitForModel) IsCloudInit() bool {
+	return m.Type.ValueString() == "cloud-init"
 }
 
 // InstanceResource represent Incus instance resource.
@@ -372,7 +377,7 @@ func (r InstanceResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 						"type": schema.StringAttribute{
 							Required: true,
 							Validators: []validator.String{
-								stringvalidator.OneOf("agent", "delay", "ipv4", "ipv6", "ready"),
+								stringvalidator.OneOf("agent", "cloud-init", "delay", "ipv4", "ipv6", "ready"),
 							},
 						},
 						"delay": schema.StringAttribute{
@@ -614,13 +619,20 @@ func validateWaitFor(ctx context.Context, config InstanceModel, resp *resource.V
 	}
 
 	for _, waitFor := range waitForList {
-		if waitFor.IsAgent() || waitFor.IsReady() {
+		if waitFor.IsAgent() || waitFor.IsCloudInit() || waitFor.IsReady() {
 			if !waitFor.Nic.IsNull() {
 				resp.Diagnostics.AddError(
 					"Invalid Configuration",
-					`"nic" can only be set when type is set to "ipv4" or "ipv6.`,
+					`"nic" can only be set when type is set to "ipv4" or "ipv6".`,
 				)
 			}
+		}
+
+		if waitFor.IsCloudInit() && !waitFor.Delay.IsNull() {
+			resp.Diagnostics.AddError(
+				"Invalid Configuration",
+				`"delay" can only be set when type is set to "delay".`,
+			)
 		}
 
 		if waitFor.IsAgent() && (config.Type.IsNull() || config.IsContainer()) {
@@ -641,7 +653,7 @@ func validateWaitFor(ctx context.Context, config InstanceModel, resp *resource.V
 			if !waitFor.Nic.IsNull() {
 				resp.Diagnostics.AddError(
 					"Invalid Configuration",
-					`"nic" can only be set when type is set to "ipv4" or "ipv6.`,
+					`"nic" can only be set when type is set to "ipv4" or "ipv6".`,
 				)
 			}
 
@@ -768,7 +780,7 @@ func (r InstanceResource) Create(ctx context.Context, req resource.CreateRequest
 
 		// Take the wait_for configurations into account.
 		if len(plan.WaitForConfigs.Elements()) > 0 {
-			diags := waitFor(ctx, server, instanceName, plan.WaitForConfigs)
+			diags := waitFor(ctx, server, instanceName, plan.WaitForConfigs, plan.IsVirtualMachine())
 			if diags != nil {
 				resp.Diagnostics.Append(diags...)
 				return
@@ -965,7 +977,7 @@ func (r InstanceResource) Update(ctx context.Context, req resource.UpdateRequest
 
 		// If instance is freshly started, we also take the wait for configurations into account.
 		if len(plan.WaitForConfigs.Elements()) > 0 {
-			diags := waitFor(ctx, server, instanceName, plan.WaitForConfigs)
+			diags := waitFor(ctx, server, instanceName, plan.WaitForConfigs, plan.IsVirtualMachine())
 			if diags != nil {
 				resp.Diagnostics.Append(diags...)
 				return
@@ -1892,7 +1904,7 @@ func stopInstance(ctx context.Context, server incus.InstanceServer, instanceName
 // waitFor waits for the instance with the given name to reach the desired
 // state. It returns an error if the instance does not reach the desired
 // state within the given timeout.
-func waitFor(ctx context.Context, server incus.InstanceServer, instanceName string, waitFor types.Set) diag.Diagnostics {
+func waitFor(ctx context.Context, server incus.InstanceServer, instanceName string, waitFor types.Set, isVirtualMachine bool) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	waitForMap, diags := ToWaitForConfigMap(ctx, waitFor)
@@ -1904,6 +1916,8 @@ func waitFor(ctx context.Context, server incus.InstanceServer, instanceName stri
 		switch waitForModelType {
 		case "agent":
 			diags = waitForInstanceAgent(ctx, server, instanceName)
+		case "cloud-init":
+			diags = waitForInstanceCloudInit(ctx, server, instanceName, isVirtualMachine)
 		case "delay":
 			duration := waitForModel.Delay.ValueString()
 			diags = waitForInstanceWithDelay(ctx, server, instanceName, duration)
@@ -2033,6 +2047,53 @@ func waitForInstanceToBeReady(ctx context.Context, server incus.InstanceServer, 
 	if err != nil {
 		var diags diag.Diagnostics
 		diags.AddError(fmt.Sprintf("Failed to wait for instance %q to be ready", instanceName), err.Error())
+		return diags
+	}
+
+	return nil
+}
+
+type cloudInitStatus struct {
+	Status string   `json:"status"`
+	Errors []string `json:"errors"`
+}
+
+// waitForInstanceCloudInit waits for cloud-init to finish inside an instance.
+func waitForInstanceCloudInit(ctx context.Context, server incus.InstanceServer, instanceName string, isVirtualMachine bool) diag.Diagnostics {
+	if isVirtualMachine {
+		diags := waitForInstanceAgent(ctx, server, instanceName)
+		if diags.HasError() {
+			return diags
+		}
+	}
+
+	execConfig := common.InstanceExecConfig{
+		Command: []string{"cloud-init", "status", "--wait", "--format", "json"},
+	}
+
+	stdout, stderr, err := common.RunInstanceExec(ctx, server, instanceName, execConfig)
+	if err != nil {
+		var diags diag.Diagnostics
+		diags.AddError(
+			fmt.Sprintf("Failed to wait for cloud-init in instance %q", instanceName),
+			formatExecError(err, stdout, stderr),
+		)
+		return diags
+	}
+
+	var status cloudInitStatus
+	if err := json.Unmarshal([]byte(stdout), &status); err != nil {
+		return nil
+	}
+
+	if status.Status == "error" || len(status.Errors) > 0 {
+		message := fmt.Sprintf("cloud-init status: %s", status.Status)
+		if len(status.Errors) > 0 {
+			message = fmt.Sprintf("%s\nerrors: %s", message, strings.Join(status.Errors, "; "))
+		}
+
+		var diags diag.Diagnostics
+		diags.AddError(fmt.Sprintf("Cloud-init failed in instance %q", instanceName), message)
 		return diags
 	}
 

--- a/internal/instance/resource_instance_test.go
+++ b/internal/instance/resource_instance_test.go
@@ -1334,6 +1334,48 @@ func TestAccInstance_waitForDelay(t *testing.T) {
 	})
 }
 
+func TestAccInstance_waitForCloudInitContainer(t *testing.T) {
+	instanceName := petname.Generate(2, "-")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstance_waitForCloudInit(instanceName, "container"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("incus_instance.instance1", "name", instanceName),
+					resource.TestCheckResourceAttr("incus_instance.instance1", "status", "Running"),
+					resource.TestCheckResourceAttr("incus_instance.instance1", "wait_for.0.type", "cloud-init"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccInstance_waitForCloudInitVM(t *testing.T) {
+	instanceName := petname.Generate(2, "-")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.PreCheckVirtualization(t)
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstance_waitForCloudInit(instanceName, "virtual-machine"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("incus_instance.instance1", "name", instanceName),
+					resource.TestCheckResourceAttr("incus_instance.instance1", "type", "virtual-machine"),
+					resource.TestCheckResourceAttr("incus_instance.instance1", "status", "Running"),
+					resource.TestCheckResourceAttr("incus_instance.instance1", "wait_for.0.type", "cloud-init"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccInstance_waitForIPv4(t *testing.T) {
 	networkName := petname.Generate(1, "-")
 	instanceName := petname.Generate(2, "-")
@@ -2313,6 +2355,24 @@ resource "incus_instance" "instance1" {
 	}
 }
 	`, projectName, instanceName, acctest.TestImage, delay)
+}
+
+func testAccInstance_waitForCloudInit(name string, instanceType string) string {
+	return fmt.Sprintf(`
+resource "incus_instance" "instance1" {
+  name  = "%s"
+  image = "images:ubuntu/24.04/cloud"
+  type = "%s"
+
+  config = {
+    "user.user-data" = "#cloud-config\nwrite_files:\n  - path: /tmp/terraform-provider-incus-cloud-init\n    content: ok\n"
+  }
+
+	wait_for {
+		type = "cloud-init"
+	}
+}
+	`, name, instanceType)
 }
 
 func testAccInstance_waitForIPv4(networkName, instanceName string) string {


### PR DESCRIPTION
This pull request fixes: https://github.com/lxc/terraform-provider-incus/issues/269 as it introduces `wait_for` type `cloud-init`.

**Example**
```hcl
resource "incus_instance" "instance1" {
  name    = "instance1"
  image   = "images:ubuntu/24.04/cloud"
  wait_for {
    type = "cloud-init"
  }
}
```

**Remark**
Is this initial implementation, we wait until cloud-init is done and reporting only an error if status is `error`. In the case the status is `done` but has a degraded state we consider it successful in the provider. 

When I tested it with Ubuntu and Alpine cloud images, I noticed that Alpine is missing certain tools that need to be installed in the cloud image, so it is in a degraded state by default. 

Reported status by cloud-init: https://docs.cloud-init.io/en/latest/howto/status.html