### PR TITLE
Fix golangci-lint install source

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,7 +133,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
+          curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(go env GOPATH)/bin
 
       - uses: hashicorp/setup-terraform@v4
         with:


### PR DESCRIPTION
This pull request fixes the issue that golangci-lint can be properly installed again.