### PR TITLE
Fix: preserve ZFS pool source config

### DIFF
--- a/internal/storage/resource_storage_pool.go
+++ b/internal/storage/resource_storage_pool.go
@@ -130,6 +130,30 @@ func (r *StoragePoolResource) Configure(_ context.Context, req resource.Configur
 	r.provider = provider
 }
 
+func (r *StoragePoolResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	// If resource is being created or destroyed, req.State or req.Plan will be null.
+	if req.State.Raw.IsNull() || req.Plan.Raw.IsNull() {
+		return
+	}
+
+	var state StoragePoolModel
+	var plan StoragePoolModel
+
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+
+	diags = req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if plan.Driver.ValueString() == "zfs" && configValueChanged(ctx, state.Config, plan.Config, "source") {
+		resp.RequiresReplace = append(resp.RequiresReplace, path.Root("config").AtMapKey("source"))
+	}
+}
+
 func (r StoragePoolResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan StoragePoolModel
 
@@ -317,6 +341,7 @@ func (r StoragePoolResource) SyncState(ctx context.Context, tfState *tfsdk.State
 
 	// Extract user defined config and merge it with current config state.
 	stateConfig := common.StripConfig(pool.Config, m.Config, m.ComputedKeys(pool.Driver))
+	stateConfig = m.PreserveUserConfig(pool.Driver, stateConfig)
 
 	// Convert config state into schema type.
 	config, diags := common.ToConfigMapType(ctx, stateConfig, m.Config)
@@ -396,4 +421,63 @@ func (StoragePoolModel) ComputedKeys(driver string) []string {
 	}
 
 	return append(keys, "volatile.")
+}
+
+// PreserveUserConfig keeps user supplied values for config keys that Incus may
+// rewrite after pool creation. This avoids apply-time state inconsistencies for
+// create-only inputs such as a ZFS source block device path.
+func (m StoragePoolModel) PreserveUserConfig(driver string, stateConfig map[string]*string) map[string]*string {
+	userConfig := map[string]*string{}
+	if !m.Config.IsNull() && !m.Config.IsUnknown() {
+		_ = m.Config.ElementsAs(context.Background(), &userConfig, false)
+	}
+
+	for _, key := range preserveUserConfigKeys(driver) {
+		value, ok := userConfig[key]
+		if ok {
+			stateConfig[key] = value
+		}
+	}
+
+	return stateConfig
+}
+
+func preserveUserConfigKeys(driver string) []string {
+	switch driver {
+	case "zfs":
+		return []string{"source"}
+	}
+
+	return nil
+}
+
+func configValueChanged(ctx context.Context, stateConfig types.Map, planConfig types.Map, key string) bool {
+	stateValue, stateOK := configValue(ctx, stateConfig, key)
+	planValue, planOK := configValue(ctx, planConfig, key)
+
+	if stateOK != planOK {
+		return true
+	}
+
+	if !stateOK {
+		return false
+	}
+
+	if stateValue == nil || planValue == nil {
+		return stateValue != planValue
+	}
+
+	return *stateValue != *planValue
+}
+
+func configValue(ctx context.Context, config types.Map, key string) (*string, bool) {
+	if config.IsNull() || config.IsUnknown() {
+		return nil, false
+	}
+
+	values := map[string]*string{}
+	_ = config.ElementsAs(ctx, &values, false)
+
+	value, ok := values[key]
+	return value, ok
 }

--- a/internal/storage/resource_storage_pool_config_test.go
+++ b/internal/storage/resource_storage_pool_config_test.go
@@ -1,0 +1,58 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestStoragePoolPreserveUserConfig_Source(t *testing.T) {
+	userSource := "/dev/disk/by-id/test-disk"
+	apiSource := "pool1"
+
+	model := StoragePoolModel{
+		Config: types.MapValueMust(types.StringType, map[string]attr.Value{
+			"source": types.StringValue(userSource),
+		}),
+	}
+
+	stateConfig := map[string]*string{
+		"source": &apiSource,
+	}
+
+	stateConfig = model.PreserveUserConfig("zfs", stateConfig)
+
+	if stateConfig["source"] == nil {
+		t.Fatal("expected source to be preserved")
+	}
+
+	if got := *stateConfig["source"]; got != userSource {
+		t.Fatalf("expected source %q, got %q", userSource, got)
+	}
+}
+
+func TestStoragePoolPreserveUserConfig_UnsupportedDriver(t *testing.T) {
+	userSource := "/dev/disk/by-id/test-disk"
+	apiSource := "pool1"
+
+	model := StoragePoolModel{
+		Config: types.MapValueMust(types.StringType, map[string]attr.Value{
+			"source": types.StringValue(userSource),
+		}),
+	}
+
+	stateConfig := map[string]*string{
+		"source": &apiSource,
+	}
+
+	stateConfig = model.PreserveUserConfig("dir", stateConfig)
+
+	if stateConfig["source"] == nil {
+		t.Fatal("expected source to remain set")
+	}
+
+	if got := *stateConfig["source"]; got != apiSource {
+		t.Fatalf("expected source %q, got %q", apiSource, got)
+	}
+}

--- a/internal/storage/resource_storage_pool_config_test.go
+++ b/internal/storage/resource_storage_pool_config_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"context"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -32,7 +33,7 @@ func TestStoragePoolPreserveUserConfig_Source(t *testing.T) {
 	}
 }
 
-func TestStoragePoolPreserveUserConfig_UnsupportedDriver(t *testing.T) {
+func TestStoragePoolPreserveUserConfig_NonZFSDriver(t *testing.T) {
 	userSource := "/dev/disk/by-id/test-disk"
 	apiSource := "pool1"
 
@@ -46,7 +47,7 @@ func TestStoragePoolPreserveUserConfig_UnsupportedDriver(t *testing.T) {
 		"source": &apiSource,
 	}
 
-	stateConfig = model.PreserveUserConfig("dir", stateConfig)
+	stateConfig = model.PreserveUserConfig("lvm", stateConfig)
 
 	if stateConfig["source"] == nil {
 		t.Fatal("expected source to remain set")
@@ -54,5 +55,37 @@ func TestStoragePoolPreserveUserConfig_UnsupportedDriver(t *testing.T) {
 
 	if got := *stateConfig["source"]; got != apiSource {
 		t.Fatalf("expected source %q, got %q", apiSource, got)
+	}
+}
+
+func TestStoragePoolConfigValueChanged(t *testing.T) {
+	ctx := context.Background()
+
+	stateConfig := types.MapValueMust(types.StringType, map[string]attr.Value{
+		"source": types.StringValue("/dev/disk/by-id/disk-a"),
+	})
+
+	planConfig := types.MapValueMust(types.StringType, map[string]attr.Value{
+		"source": types.StringValue("/dev/disk/by-id/disk-b"),
+	})
+
+	if !configValueChanged(ctx, stateConfig, planConfig, "source") {
+		t.Fatal("expected source change to be detected")
+	}
+}
+
+func TestStoragePoolConfigValueChanged_Unchanged(t *testing.T) {
+	ctx := context.Background()
+
+	stateConfig := types.MapValueMust(types.StringType, map[string]attr.Value{
+		"source": types.StringValue("/dev/disk/by-id/disk-a"),
+	})
+
+	planConfig := types.MapValueMust(types.StringType, map[string]attr.Value{
+		"source": types.StringValue("/dev/disk/by-id/disk-a"),
+	})
+
+	if configValueChanged(ctx, stateConfig, planConfig, "source") {
+		t.Fatal("expected unchanged source not to be detected as changed")
 	}
 }


### PR DESCRIPTION
This fixes: https://github.com/lxc/terraform-provider-incus/issues/437

**Description**

Incus can accept a ZFS storage pool source such as `/dev/disk/by-id/...` during creation, but later report the pool name as `config.source`. This caused Terraform/OpenTofu to fail with `Provider produced inconsistent result after apply` because the planned value differed from the post-create state.

**What's been done**

- Preserve user-configured `config.source` for ZFS storage pools when Incus rewrites the value after creation.
- Mark changes to ZFS `config.source` as requiring replacement instead of attempting an in-place update.
- Add unit coverage for preserving ZFS source config and detecting source changes.