### PR TITLE
Change storage pool config test to use storage_test package

### DIFF
--- a/internal/storage/resource_storage_pool.go
+++ b/internal/storage/resource_storage_pool.go
@@ -149,7 +149,7 @@ func (r *StoragePoolResource) ModifyPlan(ctx context.Context, req resource.Modif
 		return
 	}
 
-	if plan.Driver.ValueString() == "zfs" && configValueChanged(ctx, state.Config, plan.Config, "source") {
+	if plan.Driver.ValueString() == "zfs" && ConfigValueChanged(ctx, state.Config, plan.Config, "source") {
 		resp.RequiresReplace = append(resp.RequiresReplace, path.Root("config").AtMapKey("source"))
 	}
 }
@@ -451,7 +451,8 @@ func preserveUserConfigKeys(driver string) []string {
 	return nil
 }
 
-func configValueChanged(ctx context.Context, stateConfig types.Map, planConfig types.Map, key string) bool {
+// ConfigValueChanged returns true if the state or plan config values for the given key are different.
+func ConfigValueChanged(ctx context.Context, stateConfig types.Map, planConfig types.Map, key string) bool {
 	stateValue, stateOK := configValue(ctx, stateConfig, key)
 	planValue, planOK := configValue(ctx, planConfig, key)
 

--- a/internal/storage/resource_storage_pool_config_test.go
+++ b/internal/storage/resource_storage_pool_config_test.go
@@ -1,4 +1,4 @@
-package storage
+package storage_test
 
 import (
 	"context"
@@ -6,13 +6,15 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/lxc/terraform-provider-incus/internal/storage"
 )
 
 func TestStoragePoolPreserveUserConfig_Source(t *testing.T) {
 	userSource := "/dev/disk/by-id/test-disk"
 	apiSource := "pool1"
 
-	model := StoragePoolModel{
+	model := storage.StoragePoolModel{
 		Config: types.MapValueMust(types.StringType, map[string]attr.Value{
 			"source": types.StringValue(userSource),
 		}),
@@ -37,7 +39,7 @@ func TestStoragePoolPreserveUserConfig_NonZFSDriver(t *testing.T) {
 	userSource := "/dev/disk/by-id/test-disk"
 	apiSource := "pool1"
 
-	model := StoragePoolModel{
+	model := storage.StoragePoolModel{
 		Config: types.MapValueMust(types.StringType, map[string]attr.Value{
 			"source": types.StringValue(userSource),
 		}),
@@ -69,7 +71,7 @@ func TestStoragePoolConfigValueChanged(t *testing.T) {
 		"source": types.StringValue("/dev/disk/by-id/disk-b"),
 	})
 
-	if !configValueChanged(ctx, stateConfig, planConfig, "source") {
+	if !storage.ConfigValueChanged(ctx, stateConfig, planConfig, "source") {
 		t.Fatal("expected source change to be detected")
 	}
 }
@@ -85,7 +87,7 @@ func TestStoragePoolConfigValueChanged_Unchanged(t *testing.T) {
 		"source": types.StringValue("/dev/disk/by-id/disk-a"),
 	})
 
-	if configValueChanged(ctx, stateConfig, planConfig, "source") {
+	if storage.ConfigValueChanged(ctx, stateConfig, planConfig, "source") {
 		t.Fatal("expected unchanged source not to be detected as changed")
 	}
 }


### PR DESCRIPTION
In my last PR I accidentally scoped the storage pool config tests in the wrong package: `storage` instead of `storage_test`