### PR TITLE
Expose instance interfaces

### DIFF
--- a/cmd/generate-datasources/main.go
+++ b/cmd/generate-datasources/main.go
@@ -322,7 +322,7 @@ func initLogger(verbose bool, debug bool) {
 
 	slog.SetDefault(
 		slog.New(
-			tint.NewHandler(
+			tint.NewTextHandler(
 				os.Stderr,
 				&tint.Options{
 					Level:      level,

--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -381,6 +381,8 @@ The following attributes are exported:
 
 * `status` - The status of the instance.
 
+* `interfaces` - Map of all instance network interfaces (excluding loopback device). The map key represents the name of the network device (from Incus configuration).
+
 ## Instance Network Access
 
 If your instance has multiple network interfaces, you can specify which one

--- a/internal/common/incus_interface.go
+++ b/internal/common/incus_interface.go
@@ -1,0 +1,95 @@
+package common
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/lxc/incus/v7/shared/api"
+)
+
+// InterfaceModel represents Incus instance network interface.
+type InterfaceModel struct {
+	RealName    types.String `tfsdk:"name"`
+	State       types.String `tfsdk:"state"`
+	Type        types.String `tfsdk:"type"`
+	IPAddresses types.List   `tfsdk:"ip_addresses"`
+}
+
+// IPModel is a wrapper of the interface IP address.
+type IPModel struct {
+	Address types.String `tfsdk:"address"`
+	Family  types.String `tfsdk:"family"`
+	Scope   types.String `tfsdk:"scope"`
+}
+
+// ToInterfaceMapType converts provided intance networks into types.Map. The function
+// also accepts instance config which is used to determine configuration interface name.
+func ToInterfaceMapType(ctx context.Context, instanceNetworks map[string]api.InstanceStateNetwork, instanceConfig map[string]string) (types.Map, diag.Diagnostics) {
+	ipType := map[string]attr.Type{
+		"address": types.StringType,
+		"family":  types.StringType,
+		"scope":   types.StringType,
+	}
+
+	interfaceType := map[string]attr.Type{
+		"name":         types.StringType,
+		"state":        types.StringType,
+		"type":         types.StringType,
+		"ip_addresses": types.ListType{ElemType: types.ObjectType{AttrTypes: ipType}},
+	}
+
+	nullMap := types.MapNull(types.ObjectType{AttrTypes: interfaceType})
+	if len(instanceNetworks) == 0 {
+		return nullMap, nil
+	}
+
+	interfaces := make(map[string]InterfaceModel, len(instanceNetworks))
+	for name, net := range instanceNetworks {
+		// Find volatile entry that contains mac address of the network
+		// interface. If addresses match, extract the config name of the
+		// interface from the config key (volatile.<if_name>.hwaddr).
+		cfgInfName := ""
+		for k, v := range instanceConfig {
+			if v == net.Hwaddr {
+				cfgInfName = strings.SplitN(k, ".", 3)[1]
+				break
+			}
+		}
+
+		if cfgInfName == "" {
+			// We did not find a matching config interface, therefore
+			// do not export it.
+			continue
+		}
+
+		inf := InterfaceModel{
+			RealName: types.StringValue(name),
+			State:    types.StringValue(net.State),
+			Type:     types.StringValue(net.Type),
+		}
+
+		netAddresses := make([]IPModel, 0, len(net.Addresses))
+		for _, addr := range net.Addresses {
+			addrType := IPModel{
+				Address: types.StringValue(addr.Address),
+				Family:  types.StringValue(addr.Family),
+				Scope:   types.StringValue(addr.Scope),
+			}
+
+			netAddresses = append(netAddresses, addrType)
+		}
+
+		addresses, diags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: ipType}, netAddresses)
+		if diags.HasError() {
+			return nullMap, diags
+		}
+
+		inf.IPAddresses = addresses
+		interfaces[cfgInfName] = inf
+	}
+
+	return types.MapValueFrom(ctx, types.ObjectType{AttrTypes: interfaceType}, interfaces)
+}

--- a/internal/instance/resource_instance.go
+++ b/internal/instance/resource_instance.go
@@ -60,10 +60,11 @@ type InstanceModel struct {
 	Architecture   types.String `tfsdk:"architecture"`
 
 	// Computed.
-	IPv4   types.String `tfsdk:"ipv4_address"`
-	IPv6   types.String `tfsdk:"ipv6_address"`
-	MAC    types.String `tfsdk:"mac_address"`
-	Status types.String `tfsdk:"status"`
+	IPv4       types.String `tfsdk:"ipv4_address"`
+	IPv6       types.String `tfsdk:"ipv6_address"`
+	MAC        types.String `tfsdk:"mac_address"`
+	Status     types.String `tfsdk:"status"`
+	Interfaces types.Map    `tfsdk:"interfaces"`
 }
 
 func (m InstanceModel) IsContainer() bool {
@@ -366,6 +367,52 @@ func (r InstanceResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 
 			"status": schema.StringAttribute{
 				Computed: true,
+			},
+
+			"interfaces": schema.MapNestedAttribute{
+				Computed:    true,
+				Description: "Map of the instance network interfaces",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"name": schema.StringAttribute{
+							Computed:    true,
+							Description: "Name of the network interface within an instance",
+						},
+
+						"type": schema.StringAttribute{
+							Computed:    true,
+							Description: "Type of the network interface (link, local, global)",
+						},
+
+						"state": schema.StringAttribute{
+							Computed:    true,
+							Description: "State of the network interface (up, down)",
+						},
+
+						"ip_addresses": schema.ListNestedAttribute{
+							Computed:    true,
+							Description: "IP addresses assigned to the interface",
+							NestedObject: schema.NestedAttributeObject{
+								Attributes: map[string]schema.Attribute{
+									"address": schema.StringAttribute{
+										Computed:    true,
+										Description: "IP address",
+									},
+
+									"family": schema.StringAttribute{
+										Computed:    true,
+										Description: "IP family (inet, inet6)",
+									},
+
+									"scope": schema.StringAttribute{
+										Computed:    true,
+										Description: "Scope (local, global, link)",
+									},
+								},
+							},
+						},
+					},
+				},
 			},
 		},
 
@@ -1369,6 +1416,9 @@ func (r InstanceResource) SyncState(ctx context.Context, tfState *tfsdk.State, s
 	devices, diags := common.ToDeviceSetTypePreservingNulls(ctx, instance.Devices, m.Devices)
 	respDiags.Append(diags...)
 
+	interfaces, diags := common.ToInterfaceMapType(ctx, instanceState.Network, instance.Config)
+	respDiags.Append(diags...)
+
 	if respDiags.HasError() {
 		return respDiags
 	}
@@ -1389,6 +1439,7 @@ func (r InstanceResource) SyncState(ctx context.Context, tfState *tfsdk.State, s
 	m.Devices = devices
 	m.Config = config
 	m.Architecture = types.StringValue(instance.Architecture)
+	m.Interfaces = interfaces
 
 	// Update "running" attribute based on the instance's current status.
 	// This way, terraform will detect the change if the current status

--- a/internal/instance/resource_instance_test.go
+++ b/internal/instance/resource_instance_test.go
@@ -8,6 +8,9 @@ import (
 
 	petname "github.com/dustinkirkland/golang-petname"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
 	"github.com/lxc/terraform-provider-incus/internal/acctest"
 )
@@ -911,6 +914,38 @@ func TestAccInstance_accessInterface(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstance_accessInterface(networkName1, instanceName),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"incus_instance.instance1",
+						tfjsonpath.New("interfaces").AtMapKey("eth0").AtMapKey("name"),
+						knownvalue.StringExact("eth0"),
+					),
+					statecheck.ExpectKnownValue(
+						"incus_instance.instance1",
+						tfjsonpath.New("interfaces").AtMapKey("eth0").AtMapKey("type"),
+						knownvalue.StringExact("broadcast"),
+					),
+					statecheck.ExpectKnownValue(
+						"incus_instance.instance1",
+						tfjsonpath.New("interfaces").AtMapKey("eth0").AtMapKey("state"),
+						knownvalue.StringExact("up"),
+					),
+					statecheck.ExpectKnownValue(
+						"incus_instance.instance1",
+						tfjsonpath.New("interfaces").AtMapKey("eth0").AtMapKey("ip_addresses").AtSliceIndex(0).AtMapKey("address"),
+						knownvalue.StringExact("10.150.19.200"),
+					),
+					statecheck.ExpectKnownValue(
+						"incus_instance.instance1",
+						tfjsonpath.New("interfaces").AtMapKey("eth0").AtMapKey("ip_addresses").AtSliceIndex(0).AtMapKey("family"),
+						knownvalue.StringExact("inet"),
+					),
+					statecheck.ExpectKnownValue(
+						"incus_instance.instance1",
+						tfjsonpath.New("interfaces").AtMapKey("eth0").AtMapKey("ip_addresses").AtSliceIndex(0).AtMapKey("scope"),
+						knownvalue.StringExact("global"),
+					),
+				},
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("incus_network.network1", "name", networkName1),
 					resource.TestCheckResourceAttr("incus_network.network1", "config.ipv4.address", "10.150.19.1/24"),
@@ -923,9 +958,8 @@ func TestAccInstance_accessInterface(t *testing.T) {
 					resource.TestCheckResourceAttr("incus_instance.instance1", "device.0.type", "nic"),
 					resource.TestCheckResourceAttr("incus_instance.instance1", "device.0.properties.nictype", "bridged"),
 					resource.TestCheckResourceAttr("incus_instance.instance1", "device.0.properties.parent", networkName1),
-					resource.TestCheckResourceAttr("incus_instance.instance1", "device.0.properties.hwaddr", "00:16:3e:39:7f:36"),
 					resource.TestCheckResourceAttr("incus_instance.instance1", "device.0.properties.ipv4.address", "10.150.19.200"),
-					resource.TestCheckResourceAttr("incus_instance.instance1", "mac_address", "00:16:3e:39:7f:36"),
+					resource.TestCheckResourceAttrSet("incus_instance.instance1", "mac_address"),
 					resource.TestCheckResourceAttr("incus_instance.instance1", "ipv4_address", "10.150.19.200"),
 					resource.TestCheckResourceAttrSet("incus_instance.instance1", "ipv6_address"),
 				),
@@ -2072,10 +2106,10 @@ resource "incus_instance" "instance1" {
     "user.access_interface" = "eth0"
   }
 
-	wait_for {
-		type = "ipv4"
-		nic = "eth0"
-	}
+  wait_for {
+    type = "ipv4"
+    nic = "eth0"
+  }
 
   device {
     name = "eth0"
@@ -2084,7 +2118,6 @@ resource "incus_instance" "instance1" {
     properties = {
       nictype        = "bridged"
       parent         = "${incus_network.network1.name}"
-      hwaddr         = "00:16:3e:39:7f:36"
       "ipv4.address" = "10.150.19.200"
     }
   }


### PR DESCRIPTION
This pull request adds the capability to access the information for all network interfaces of an instance, see https://github.com/lxc/terraform-provider-incus/issues/452

**Example**

```hcl
resource "incus_instance" "d1" {
  name  = "d1"
  image = "images:debian/13"
}

output "interfaces" {
  value = incus_instance.d1.interfaces
}
```

```
$ tofu apply
...

Outputs:

interfaces = tomap({
  "eth0" = {
    "ip_addresses" = tolist([
      {
        "address" = "10.70.154.109"
        "family" = "inet"
        "scope" = "global"
      },
      {
        "address" = "fd42:7acd:90c7:3afa:1266:6aff:fec6:a3f"
        "family" = "inet6"
        "scope" = "global"
      },
      {
        "address" = "fe80::1266:6aff:fec6:a3f"
        "family" = "inet6"
        "scope" = "link"
      },
    ])
    "name" = "eth0"
    "state" = "up"
    "type" = "broadcast"
  }
})
```

**What's been done**
- instance: Expose Instance interfaces
- tests: Expose Instance interfaces
- docs: Expose Instance interfaces
