### PR TITLE
Fix provider and acceptance-test race conditions

### DIFF
--- a/internal/common/incus_exec.go
+++ b/internal/common/incus_exec.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -33,6 +34,25 @@ type InstanceExecConfig struct {
 	Timeout     time.Duration
 	HasTimeout  bool
 	Trigger     string
+}
+
+type lockedBuffer struct {
+	mux    sync.Mutex
+	buffer bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(data []byte) (int, error) {
+	b.mux.Lock()
+	defer b.mux.Unlock()
+
+	return b.buffer.Write(data)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mux.Lock()
+	defer b.mux.Unlock()
+
+	return b.buffer.String()
 }
 
 func ToExecMap(ctx context.Context, execMap types.Map) (map[string]InstanceExecModel, diag.Diagnostics) {
@@ -175,8 +195,8 @@ func RunInstanceExec(ctx context.Context, server incus.InstanceServer, instanceN
 		execReq.Group = uint32(execConfig.GroupID)
 	}
 
-	stdout := &bytes.Buffer{}
-	stderr := &bytes.Buffer{}
+	stdout := &lockedBuffer{}
+	stderr := &lockedBuffer{}
 
 	execArgs := incus.InstanceExecArgs{
 		Stdout:   stdout,

--- a/internal/image/resource_image_test.go
+++ b/internal/image/resource_image_test.go
@@ -355,6 +355,7 @@ func TestAccImage_sourceInstanceWithSnapshot(t *testing.T) {
 }
 
 func TestAccImage_sourceFileSplitImage(t *testing.T) {
+	projectName := petname.Generate(2, "-")
 	tmpDir := t.TempDir()
 	targetMetadata := filepath.Join(tmpDir, `alpine-edge.img`)
 	targetData := targetMetadata + ".root"
@@ -376,7 +377,7 @@ func TestAccImage_sourceFileSplitImage(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSourceFileSplitImage_exportImage(targetMetadata),
+				Config: testAccSourceFileSplitImage_exportImage(projectName, targetMetadata),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("incus_image.img1", "source_image.remote", "images"),
 					resource.TestCheckResourceAttr("incus_image.img1", "source_image.name", "alpine/edge"),
@@ -389,7 +390,7 @@ func TestAccImage_sourceFileSplitImage(t *testing.T) {
 				Config: `#`, // Empty config to remove image. Comment is required, since empty string is seen as zero value.
 			},
 			{
-				Config: testAccSourceFileSplitImage_fromFile(targetData, targetMetadata, alias1, alias2),
+				Config: testAccSourceFileSplitImage_fromFile(projectName, targetData, targetMetadata, alias1, alias2),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("incus_image.from_file", "source_file.data_path", targetData),
 					resource.TestCheckResourceAttr("incus_image.from_file", "source_file.metadata_path", targetMetadata),
@@ -757,9 +758,15 @@ resource "incus_image" "img1" {
 	`, projectName, instanceName, acctest.TestImage)
 }
 
-func testAccSourceFileSplitImage_exportImage(target string) string {
+func testAccSourceFileSplitImage_exportImage(projectName, target string) string {
 	return fmt.Sprintf(`
+resource "incus_project" "project1" {
+  name = "%[1]s"
+}
+
 resource "incus_image" "img1" {
+  project = incus_project.project1.name
+
   source_image = {
     remote       = "images"
     name         = "alpine/edge"
@@ -769,29 +776,35 @@ resource "incus_image" "img1" {
 
 resource "null_resource" "export_img1" {
   provisioner "local-exec" {
-    command = "incus image export ${incus_image.img1.fingerprint} %[1]s"
+    command = "incus image export --project ${incus_project.project1.name} ${incus_image.img1.fingerprint} %[2]s"
   }
 }
-`, target)
+`, projectName, target)
 }
 
-func testAccSourceFileSplitImage_fromFile(targetData, targetMetadata string, alias1, alias2 string) string {
+func testAccSourceFileSplitImage_fromFile(projectName, targetData, targetMetadata, alias1, alias2 string) string {
 	return fmt.Sprintf(`
-resource "incus_image" "from_file" {
-  source_file = {
-    data_path     = "%[1]s"
-    metadata_path = "%[2]s"
-  }
+resource "incus_project" "project1" {
+  name = "%[1]s"
+}
 
-  alias {
-    name = "%[3]s"
+resource "incus_image" "from_file" {
+  project = incus_project.project1.name
+
+  source_file = {
+    data_path     = "%[2]s"
+    metadata_path = "%[3]s"
   }
 
   alias {
     name = "%[4]s"
   }
+
+  alias {
+    name = "%[5]s"
+  }
 }
-`, targetData, targetMetadata, alias1, alias2)
+`, projectName, targetData, targetMetadata, alias1, alias2)
 }
 
 func testAccSourceFileUnifiedImage_exportImage(name, targetData string) string {

--- a/internal/instance/resource_instance_test.go
+++ b/internal/instance/resource_instance_test.go
@@ -1679,6 +1679,18 @@ func testAccInstance_started(name string, instanceType string) string {
 		config = `"security.secureboot" = false`
 	}
 
+	waitForNetworkConfig := `
+  wait_for {
+    type = "ipv4"
+    nic  = "eth0"
+  }
+
+  wait_for {
+    type = "ipv6"
+    nic  = "eth0"
+  }
+`
+
 	var waitForAgentConfig string
 	if instanceType == "virtual-machine" {
 		waitForAgentConfig = `wait_for { type = "agent" }`
@@ -1696,8 +1708,9 @@ resource "incus_instance" "instance1" {
   }
 
 	%s
+  %s
 }
-	`, name, acctest.TestImage, instanceType, config, waitForAgentConfig)
+	`, name, acctest.TestImage, instanceType, config, waitForNetworkConfig, waitForAgentConfig)
 }
 
 func testAccInstance_stopped(name string, instanceType string) string {

--- a/internal/instance/resource_instance_test.go
+++ b/internal/instance/resource_instance_test.go
@@ -1069,7 +1069,12 @@ func TestAccInstance_importBasic(t *testing.T) {
 				ImportStateId:                        fmt.Sprintf("%s,image=%s", instanceName, acctest.TestImage),
 				ImportStateVerifyIdentifierAttribute: "name",
 				ImportStateVerify:                    true,
-				ImportState:                          true,
+				ImportStateVerifyIgnore: []string{
+					"interfaces",
+					"ipv4_address",
+					"ipv6_address",
+				},
+				ImportState: true,
 			},
 		},
 	})
@@ -1092,7 +1097,12 @@ func TestAccInstance_importProject(t *testing.T) {
 				ImportStateId:                        fmt.Sprintf("%s/%s,image=%s", projectName, instanceName, acctest.TestImage),
 				ImportStateVerifyIdentifierAttribute: "name",
 				ImportStateVerify:                    true,
-				ImportState:                          true,
+				ImportStateVerifyIgnore: []string{
+					"interfaces",
+					"ipv4_address",
+					"ipv6_address",
+				},
+				ImportState: true,
 			},
 		},
 	})

--- a/internal/network/resource_network_test.go
+++ b/internal/network/resource_network_test.go
@@ -375,6 +375,16 @@ resource "incus_instance" "instance1" {
   name     = "%s"
   image    = "%s"
   profiles = ["default", incus_profile.profile1.name]
+
+  wait_for {
+    type = "ipv4"
+    nic  = "eth0"
+  }
+
+  wait_for {
+    type = "ipv6"
+    nic  = "eth0"
+  }
 }
 `, profileName, instanceName, acctest.TestImage)
 }

--- a/internal/provider-config/config.go
+++ b/internal/provider-config/config.go
@@ -581,8 +581,8 @@ func (p *IncusProviderConfig) setIncusConfigRemote(name string, remote incus_con
 // getIncusConfigInstanceServer will retrieve an IncusInstanceServer client
 // in a conncurrent-safe way.
 func (p *IncusProviderConfig) getIncusConfigInstanceServer(remoteName string) (incus.InstanceServer, error) {
-	p.mux.RLock()
-	defer p.mux.RUnlock()
+	p.mux.Lock()
+	defer p.mux.Unlock()
 
 	server, err := p.incusConfig.GetInstanceServer(remoteName)
 	if err != nil {
@@ -602,7 +602,7 @@ func (p *IncusProviderConfig) getIncusConfigInstanceServer(remoteName string) (i
 // getIncusConfigImageServer will retrieve an IncusImageServer client
 // in a conncurrent-safe way.
 func (p *IncusProviderConfig) getIncusConfigImageServer(remoteName string) (incus.ImageServer, error) {
-	p.mux.RLock()
-	defer p.mux.RUnlock()
+	p.mux.Lock()
+	defer p.mux.Unlock()
 	return p.incusConfig.GetImageServer(remoteName)
 }

--- a/internal/provider-config/config_concurrency_test.go
+++ b/internal/provider-config/config_concurrency_test.go
@@ -1,0 +1,42 @@
+package config
+
+import (
+	"sync"
+	"testing"
+
+	incus_config "github.com/lxc/incus/v7/shared/cliconfig"
+)
+
+func TestGetIncusConfigInstanceServerConcurrent(t *testing.T) {
+	const attempts = 10
+	const clients = 64
+	const remoteName = "test"
+
+	for range attempts {
+		incusConfig := incus_config.NewConfig(t.TempDir(), false)
+		incusConfig.Remotes = map[string]incus_config.Remote{
+			remoteName: {
+				Addrs:    []string{"https://127.0.0.1:0"},
+				Protocol: "incus",
+			},
+		}
+
+		provider := NewIncusProvider(incusConfig, false)
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+
+		for range clients {
+			wg.Go(func() {
+				<-start
+				_, _ = provider.getIncusConfigInstanceServer(remoteName)
+			})
+		}
+
+		close(start)
+		wg.Wait()
+
+		if incusConfig.Remotes[remoteName].TLS == nil {
+			t.Fatal("client certificate was not cached")
+		}
+	}
+}


### PR DESCRIPTION
This pull request fixes https://github.com/lxc/terraform-provider-incus/issues/469.

---

**Description**

Incus lazily caches TLS credentials in the shared client configuration. Concurrent client creation could therefore access the remotes map concurrently.

This PR serializes Incus client creation. It also fixes a separate race when an instance exec command times out while Incus is still copying WebSocket output.

**What's been done**

- provider: Prevent concurrent access to the shared Incus configuration
- common: Fix race in instance exec output
- tests: Add a concurrent client creation regression test
- tests: Wait for network addresses before asserting them
- tests: Isolate split image import in project
- tests: Ignore computed network fields on import